### PR TITLE
Bump crossfont to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ smithay-client-toolkit = "0.16"
 tiny-skia = { version = "0.6.3", features = ["std", "simd"] }
 log = "0.4"
 
-crossfont = { version = "0.4.0", optional = true }
+crossfont = { version = "0.5.0", features = ["force_system_fontconfig"], optional = true }
 
 [features]
 # default = ["title"]

--- a/src/title/crossfont_renderer.rs
+++ b/src/title/crossfont_renderer.rs
@@ -42,7 +42,7 @@ impl CrossfontTitleText {
             },
         );
 
-        let mut rasterizer = crossfont::Rasterizer::new(scale as f32, false)?;
+        let mut rasterizer = crossfont::Rasterizer::new(scale as f32)?;
         let size = crossfont::Size::new(10.0);
         let font_key = rasterizer.load_font(&font_desc, size)?;
 


### PR DESCRIPTION
This also enforces the use of system libraries.