### PR TITLE
Fix title clipping

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -661,7 +661,7 @@ fn draw_headerbar(
 
         let x = x.max(margin_h + 5.0);
 
-        if let Some(clip) = Rect::from_xywh(0.0, 0.0, buttons.minimize.x() - 10.0, header_h) {
+        if let Some(clip) = Rect::from_xywh(0.0, 0.0, buttons.minimize.x() - 10.0, canvas_h) {
             let mut mask = ClipMask::new();
             mask.set_path(
                 canvas_w as u32,


### PR DESCRIPTION
The example title text descents are being clipped. This PR removes that.

## Before
![](https://user-images.githubusercontent.com/2331607/184533304-b8bb3083-6fcd-4b3c-b051-749ab5cf3abb.png)

## After
![](https://user-images.githubusercontent.com/2331607/184533306-5eb885a3-3ef8-4123-86dd-af5d2dbc585a.png)
