### PR TITLE
Fix crossfont render color typo

### DIFF
--- a/src/title/crossfont_renderer.rs
+++ b/src/title/crossfont_renderer.rs
@@ -170,8 +170,8 @@ impl CrossfontTitleText {
                 let color = color.premultiply().to_color_u8();
 
                 buffer.push(color.red());
-                buffer.push(color.red());
                 buffer.push(color.green());
+                buffer.push(color.blue());
                 buffer.push(color.alpha());
             }
 


### PR DESCRIPTION
I noticed this, looks like a typo. I don't think it has any negative effect currently because all font colors are grey at the moment. But probably worth fixing anyway.