### PR TITLE
Use dbus to hint dark theme preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased (0.5.1)
-- Use gsettings to automatically choose light or dark theming.
+- Use dbus org.freedesktop.portal.Settings to automatically choose light or dark theming.
 
 ## 0.5.0
 - `title` feature got removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased (0.5.1)
+- Use gsettings to automatically choose light or dark theming.
+
 ## 0.5.0
 - `title` feature got removed
 - `ab_glyph` default feature got added (for `ab_glyph` based title rendering)

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -40,7 +40,9 @@ fn main() {
         .expect("Failed to create a window !");
 
     window.set_title("/usr/lib/xorg/modules/input".to_string());
-    window.set_frame_config(sctk_adwaita::FrameConfig::light());
+
+    // // uncomment to override automatic theme selection
+    // window.set_frame_config(sctk_adwaita::FrameConfig::light());
 
     let mut pool = env
         .create_auto_pool()
@@ -85,7 +87,6 @@ fn main() {
     }
 }
 
-#[allow(clippy::many_single_char_names)]
 fn redraw(
     pool: &mut AutoMemPool,
     surface: &wl_surface::WlSurface,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,16 @@
+//! System configuration.
+use std::process::Command;
+
+/// Query system to see if dark theming should be preferred.
+pub(crate) fn prefer_dark() -> bool {
+    let gsettings_color_scheme = Command::new("gsettings")
+        .args(&["get", "org.gnome.desktop.interface", "color-scheme"])
+        .output()
+        .ok()
+        .and_then(|out| String::from_utf8(out.stdout).ok());
+    let color_scheme = gsettings_color_scheme
+        .as_ref()
+        .map(|o| o.trim().trim_matches('\''));
+
+    matches!(color_scheme, Some("prefer-dark"))
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,14 +3,17 @@ use std::process::Command;
 
 /// Query system to see if dark theming should be preferred.
 pub(crate) fn prefer_dark() -> bool {
-    let gsettings_color_scheme = Command::new("gsettings")
-        .args(&["get", "org.gnome.desktop.interface", "color-scheme"])
+    // outputs something like: `variant       variant          uint32 1`
+    let stdout = Command::new("dbus-send")
+        .arg("--print-reply=literal")
+        .arg("--dest=org.freedesktop.portal.Desktop")
+        .arg("/org/freedesktop/portal/desktop")
+        .arg("org.freedesktop.portal.Settings.Read")
+        .arg("string:org.freedesktop.appearance")
+        .arg("string:color-scheme")
         .output()
         .ok()
         .and_then(|out| String::from_utf8(out.stdout).ok());
-    let color_scheme = gsettings_color_scheme
-        .as_ref()
-        .map(|o| o.trim().trim_matches('\''));
 
-    matches!(color_scheme, Some("prefer-dark"))
+    matches!(stdout, Some(s) if s.trim().ends_with("uint32 1"))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,37 +1,31 @@
-use std::cell::RefCell;
-use std::fmt;
-use std::rc::Rc;
+mod buttons;
+mod config;
+mod parts;
+mod pointer;
+mod surface;
+pub mod theme;
+mod title;
 
+use crate::theme::ColorMap;
+use buttons::{ButtonKind, Buttons};
+use client::{
+    protocol::{wl_compositor, wl_seat, wl_shm, wl_subcompositor, wl_surface},
+    Attached, DispatchData,
+};
 use parts::Parts;
 use pointer::PointerUserData;
-use smithay_client_toolkit::reexports::client;
-
-use client::protocol::{wl_compositor, wl_seat, wl_shm, wl_subcompositor, wl_surface};
-use client::{Attached, DispatchData};
-use tiny_skia::{
-    ClipMask, Color, FillRule, Paint, Path, PathBuilder, Pixmap, PixmapMut, PixmapPaint, Point,
-    Rect, Transform,
-};
-
 use smithay_client_toolkit::{
+    reexports::client,
     seat::pointer::{ThemeManager, ThemeSpec, ThemedPointer},
     shm::AutoMemPool,
     window::{Frame, FrameRequest, State, WindowState},
 };
-
-pub mod theme;
+use std::{cell::RefCell, fmt, rc::Rc};
 use theme::{ColorTheme, BORDER_SIZE, HEADER_SIZE};
-
-mod buttons;
-use buttons::{ButtonKind, Buttons};
-
-use crate::theme::ColorMap;
-
-mod parts;
-mod pointer;
-mod surface;
-
-mod title;
+use tiny_skia::{
+    ClipMask, Color, FillRule, Paint, Path, PathBuilder, Pixmap, PixmapMut, PixmapPaint, Point,
+    Rect, Transform,
+};
 use title::TitleText;
 
 type SkiaResult = Option<()>;
@@ -133,6 +127,12 @@ pub struct FrameConfig {
 }
 
 impl FrameConfig {
+    pub fn auto() -> Self {
+        Self {
+            theme: ColorTheme::auto(),
+        }
+    }
+
     pub fn light() -> Self {
         Self {
             theme: ColorTheme::light(),
@@ -198,7 +198,7 @@ impl Frame for AdwaitaFrame {
 
         let pool = AutoMemPool::new(shm.clone())?;
 
-        let colors = ColorTheme::default();
+        let colors = ColorTheme::auto();
 
         Ok(AdwaitaFrame {
             base_surface: base_surface.clone(),

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -69,6 +69,15 @@ impl Default for ColorTheme {
 }
 
 impl ColorTheme {
+    /// Automatically choose between light & dark themes based on:
+    /// * gsettings get org.gnome.desktop.interface color-scheme
+    pub fn auto() -> Self {
+        match crate::config::prefer_dark() {
+            true => Self::dark(),
+            false => Self::light(),
+        }
+    }
+
     pub fn light() -> Self {
         Self {
             active: ColorMap {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -70,7 +70,8 @@ impl Default for ColorTheme {
 
 impl ColorTheme {
     /// Automatically choose between light & dark themes based on:
-    /// * gsettings get org.gnome.desktop.interface color-scheme
+    /// * dbus org.freedesktop.portal.Settings
+    ///   <https://flatpak.github.io/xdg-desktop-portal/#gdbus-interface-org-freedesktop-portal-Settings>
     pub fn auto() -> Self {
         match crate::config::prefer_dark() {
             true => Self::dark(),


### PR DESCRIPTION
Automatically select light/dark theme by querying `org.gnome.desktop.interface.color-scheme` which indicates the light or dark selection in modern gnome "Appearance" settings.

Perhaps there is a better way to query gsettings than running the bin as a command? For me this takes ~2.5ms to run which will happen once on init. Using command is fairly simple and  means no additional dependencies at least.