### PR TITLE
ab_glyph titles: try to use system sans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- `ab_glyph` feature will attempt to use system default font for consistency with `crossfont` feature.
+
 ## 0.5.1
 - Use dbus org.freedesktop.portal.Settings to automatically choose light or dark theming.
 - Double click detection fix.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4"
 # Draw title text using crossfont `--features crossfont`
 crossfont = { version = "0.5.0", features = ["force_system_fontconfig"], optional = true }
 # Draw title text using ab_glyph `--features ab_glyph`
-ab_glyph = { version = "0.2.15", optional = true }
+ab_glyph = { version = "0.2.16", optional = true }
 
 [features]
 default = ["ab_glyph"]

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -135,7 +135,7 @@ fn lmb_press(
     maximized: bool,
     resizable: bool,
 ) -> Option<FrameRequest> {
-    let req = match pointer_data.location {
+    match pointer_data.location {
         Location::Top if resizable => Some(FrameRequest::Resize(
             pointer_data.seat.clone(),
             ResizeEdge::Top,
@@ -192,9 +192,7 @@ fn lmb_press(
             None
         }
         _ => None,
-    };
-
-    req
+    }
 }
 
 fn lmb_release(pointer_data: &mut PointerUserData, maximized: bool) -> Option<FrameRequest> {


### PR DESCRIPTION
When using `ab_glyph` feature title text try to use system sans font if possible for consistency with `crossfont` feature.

### `ab_glyph` system sans
![](https://user-images.githubusercontent.com/2331607/186504701-fa01bbdf-9b49-4ece-aba5-487e6014b136.png)

### `crossfont` system sans
![](https://user-images.githubusercontent.com/2331607/186504730-666c4e7c-2df4-4c89-92dd-4b56687eee85.png)

## Issues/alternatives
* Instead of `Command` a pure rust fontconfig could work. However, the former does mean no extra dependencies so it's a tradeoff.
* Currently read the system font into heap. We could instead mmap, though I think we'd have to do this for each render call rather than at startup due to borrowing/self ref rules.

## Next steps

I think it makes sense to also lookup from system config the font config for window titles rather than using `sans`.
* Window title font name
* Size
* Variant

For example my gnome tweaks seems to think **"Legacy Window Titles"** should use **"Cantarell Bold 12"**. I'm not sure how to access this data in the most cross-distro way.

Resolves #11 