### PR TITLE
Use system titlebar-font config if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## Unreleased
-- `ab_glyph` feature will attempt to use system default font for consistency with `crossfont` feature.
+## Unreleased (0.5.2)
+- `ab_glyph` & `crossfont` titles will use gnome "titlebar-font" config if available.
+- `ab_glyph` titles are now more consistent with `crossfont` titles both using system sans
+  if no better font config is available.
 
 ## 0.5.1
 - Use dbus org.freedesktop.portal.Settings to automatically choose light or dark theming.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,8 @@ ab_glyph = { version = "0.2.16", optional = true }
 
 [features]
 default = ["ab_glyph"]
+
+# TODO rm and use new releases
+[patch.crates-io]
+owned_ttf_parser = { git = "https://github.com/alexheretic/owned-ttf-parser" }
+ab_glyph = { git = "https://github.com/alexheretic/ab-glyph", branch = "variations" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,7 @@ log = "0.4"
 # Draw title text using crossfont `--features crossfont`
 crossfont = { version = "0.5.0", features = ["force_system_fontconfig"], optional = true }
 # Draw title text using ab_glyph `--features ab_glyph`
-ab_glyph = { version = "0.2.16", optional = true }
+ab_glyph = { version = "0.2.17", optional = true }
 
 [features]
 default = ["ab_glyph"]
-
-# TODO rm and use new releases
-[patch.crates-io]
-owned_ttf_parser = { git = "https://github.com/alexheretic/owned-ttf-parser" }
-ab_glyph = { git = "https://github.com/alexheretic/ab-glyph", branch = "variations" }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -13,7 +13,7 @@ fn main() {
 
     let mut event_loop = calloop::EventLoop::<Option<WEvent>>::try_new().unwrap();
 
-    let mut dimensions = (320u32, 240u32);
+    let mut dimensions = (380u32, 240u32);
 
     let surface = env.create_surface().detach();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 //! System configuration.
+use crate::title::font_preference::FontPreference;
 use std::process::Command;
 
 /// Query system to see if dark theming should be preferred.
@@ -16,4 +17,21 @@ pub(crate) fn prefer_dark() -> bool {
         .and_then(|out| String::from_utf8(out.stdout).ok());
 
     matches!(stdout, Some(s) if s.trim().ends_with("uint32 1"))
+}
+
+/// Query system for which font to use for window titles.
+pub(crate) fn titlebar_font() -> Option<FontPreference> {
+    // outputs something like: `'Cantarell Bold 12'`
+    let stdout = Command::new("gsettings")
+        .args(["get", "org.gnome.desktop.wm.preferences", "titlebar-font"])
+        .output()
+        .ok()
+        .and_then(|out| String::from_utf8(out.stdout).ok())?;
+
+    FontPreference::from_name_style_size(
+        stdout
+            .trim()
+            .trim_end_matches('\'')
+            .trim_start_matches('\''),
+    )
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,4 @@
 //! System configuration.
-use crate::title::font_preference::FontPreference;
 use std::process::Command;
 
 /// Query system to see if dark theming should be preferred.
@@ -17,21 +16,4 @@ pub(crate) fn prefer_dark() -> bool {
         .and_then(|out| String::from_utf8(out.stdout).ok());
 
     matches!(stdout, Some(s) if s.trim().ends_with("uint32 1"))
-}
-
-/// Query system for which font to use for window titles.
-pub(crate) fn titlebar_font() -> Option<FontPreference> {
-    // outputs something like: `'Cantarell Bold 12'`
-    let stdout = Command::new("gsettings")
-        .args(["get", "org.gnome.desktop.wm.preferences", "titlebar-font"])
-        .output()
-        .ok()
-        .and_then(|out| String::from_utf8(out.stdout).ok())?;
-
-    FontPreference::from_name_style_size(
-        stdout
-            .trim()
-            .trim_end_matches('\'')
-            .trim_start_matches('\''),
-    )
 }

--- a/src/title.rs
+++ b/src/title.rs
@@ -1,5 +1,7 @@
 use tiny_skia::{Color, Pixmap};
 
+pub mod font_preference;
+
 #[cfg(feature = "crossfont")]
 mod crossfont_renderer;
 

--- a/src/title.rs
+++ b/src/title.rs
@@ -1,6 +1,9 @@
 use tiny_skia::{Color, Pixmap};
 
-pub mod font_preference;
+#[cfg(any(feature = "crossfont", feature = "ab_glyph"))]
+mod config;
+#[cfg(any(feature = "crossfont", feature = "ab_glyph"))]
+mod font_preference;
 
 #[cfg(feature = "crossfont")]
 mod crossfont_renderer;

--- a/src/title/ab_glyph_renderer.rs
+++ b/src/title/ab_glyph_renderer.rs
@@ -1,7 +1,7 @@
 //! Title renderer using ab_glyph & Cantarell-Regular.ttf (SIL Open Font Licence v1.1).
 //!
 //! Uses embedded font & requires no dynamically linked dependencies.
-use crate::{config, title::font_preference::FontPreference};
+use crate::title::{config, font_preference::FontPreference};
 use ab_glyph::{point, Font, FontArc, FontVec, Glyph, PxScale, ScaleFont, VariableFont};
 use std::{
     fs::File,

--- a/src/title/config.rs
+++ b/src/title/config.rs
@@ -1,0 +1,20 @@
+//! System font configuration.
+use crate::title::font_preference::FontPreference;
+use std::process::Command;
+
+/// Query system for which font to use for window titles.
+pub(crate) fn titlebar_font() -> Option<FontPreference> {
+    // outputs something like: `'Cantarell Bold 12'`
+    let stdout = Command::new("gsettings")
+        .args(["get", "org.gnome.desktop.wm.preferences", "titlebar-font"])
+        .output()
+        .ok()
+        .and_then(|out| String::from_utf8(out.stdout).ok())?;
+
+    FontPreference::from_name_style_size(
+        stdout
+            .trim()
+            .trim_end_matches('\'')
+            .trim_start_matches('\''),
+    )
+}

--- a/src/title/crossfont_renderer.rs
+++ b/src/title/crossfont_renderer.rs
@@ -1,3 +1,4 @@
+use crate::config;
 use crossfont::{GlyphKey, Rasterize, RasterizedGlyph};
 use tiny_skia::{Color, Pixmap, PixmapPaint, PixmapRef, Transform};
 
@@ -33,17 +34,18 @@ impl CrossfontTitleText {
         let title = "".into();
         let scale = 1;
 
-        let font_desc = crossfont::FontDesc::new(
-            // "monospace",
-            "sans-serif",
-            crossfont::Style::Description {
+        let font_pref = config::titlebar_font().unwrap_or_default();
+        let font_style = font_pref
+            .style
+            .map(crossfont::Style::Specific)
+            .unwrap_or_else(|| crossfont::Style::Description {
                 slant: crossfont::Slant::Normal,
                 weight: crossfont::Weight::Normal,
-            },
-        );
+            });
+        let font_desc = crossfont::FontDesc::new(&font_pref.name, font_style);
 
         let mut rasterizer = crossfont::Rasterizer::new(scale as f32)?;
-        let size = crossfont::Size::new(10.0);
+        let size = crossfont::Size::new(font_pref.pt_size);
         let font_key = rasterizer.load_font(&font_desc, size)?;
 
         // Need to load at least one glyph for the face before calling metrics.

--- a/src/title/crossfont_renderer.rs
+++ b/src/title/crossfont_renderer.rs
@@ -1,4 +1,4 @@
-use crate::config;
+use crate::title::config;
 use crossfont::{GlyphKey, Rasterize, RasterizedGlyph};
 use tiny_skia::{Color, Pixmap, PixmapPaint, PixmapRef, Transform};
 

--- a/src/title/font_preference.rs
+++ b/src/title/font_preference.rs
@@ -1,0 +1,64 @@
+#[derive(Debug)]
+pub(crate) struct FontPreference {
+    pub name: String,
+    pub style: Option<String>,
+    pub pt_size: f32,
+}
+
+impl Default for FontPreference {
+    fn default() -> Self {
+        Self {
+            name: "sans-serif".into(),
+            style: None,
+            pt_size: 10.0,
+        }
+    }
+}
+
+impl FontPreference {
+    /// Parse config string like `Cantarell 12` or `Cantarell Bold 11`.
+    pub fn from_name_style_size(conf: &str) -> Option<Self> {
+        let mut split = conf.split(' ');
+        let name = split.next()?;
+        let mut style = split.next();
+        let mut pt_size = split.next();
+        if let (Some(v), None) = (style, pt_size) {
+            if v.chars().all(|c| c.is_numeric() || c == '.') {
+                pt_size = Some(v);
+                style = None;
+            }
+        }
+
+        let pt_size = pt_size.and_then(|p| p.parse().ok()).unwrap_or(10.0);
+
+        Some(Self {
+            name: name.into(),
+            style: style.map(|v| v.into()),
+            pt_size,
+        })
+    }
+}
+
+#[test]
+fn pref_from_name_variant_size() {
+    let pref = FontPreference::from_name_style_size("Cantarell Bold 12").unwrap();
+    assert_eq!(pref.name, "Cantarell");
+    assert_eq!(pref.style, Some("Bold".into()));
+    assert!((pref.pt_size - 12.0).abs() < f32::EPSILON);
+}
+
+#[test]
+fn pref_from_name_size() {
+    let pref = FontPreference::from_name_style_size("Cantarell 12").unwrap();
+    assert_eq!(pref.name, "Cantarell");
+    assert_eq!(pref.style, None);
+    assert!((pref.pt_size - 12.0).abs() < f32::EPSILON);
+}
+
+#[test]
+fn pref_from_name() {
+    let pref = FontPreference::from_name_style_size("Cantarell").unwrap();
+    assert_eq!(pref.name, "Cantarell");
+    assert_eq!(pref.style, None);
+    assert!((pref.pt_size - 10.0).abs() < f32::EPSILON);
+}


### PR DESCRIPTION
This PR uses **gsettings** bin to read `org.gnome.desktop.wm.preferences titlebar-font` _(is there a better way to query this?)_ and use this to configure the font used to render the title (`ab_glyph` and `crossfont`).

If no system font preference is found the default will remain sans:10.

## Gnome
Using gnome (which I'm using) this means the titles look the same as native.

_Example: Top system settings app title, middle `ab_glyph` example title, bottom `crossfont` example title_
![settings-ab-cross](https://user-images.githubusercontent.com/2331607/188285651-10abac39-6016-48c6-b20f-5947d936be63.png)

~Requires a new _ab_glyph_ & _owned_ttf_parser_ release to support variable font bold logic.~ Update: done.