### PR TITLE
Use memory mapped system fonts for ab_glyph titles instead of keeping in RAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased (0.5.3)
 - `ab_glyph` titles will read the system title font using memory mapped buffers instead of reading to heap.
-   Lowers RAM usage.
+  Lowers RAM usage.
+- Improve titlebar-font config parsing to correctly handle more font names.
 
 ## 0.5.2
 - `ab_glyph` & `crossfont` titles will use gnome "titlebar-font" config if available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased (0.5.3)
+- `ab_glyph` titles will read the system title font using memory mapped buffers instead of reading to heap.
+   Lowers RAM usage.
+
 ## 0.5.2
 - `ab_glyph` & `crossfont` titles will use gnome "titlebar-font" config if available.
 - `ab_glyph` titles are now more consistent with `crossfont` titles both using system sans

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ description = "Adwaita-like SCTK Frame"
 smithay-client-toolkit = "0.16"
 tiny-skia = { version = "0.8", features = ["std", "simd"] }
 log = "0.4"
+memmap2 = "0.5.8"
 
 # Draw title text using crossfont `--features crossfont`
 crossfont = { version = "0.5.0", features = ["force_system_fontconfig"], optional = true }

--- a/src/buttons.rs
+++ b/src/buttons.rs
@@ -138,7 +138,7 @@ impl Button {
         );
 
         let path2 = {
-            let size = 8.0 * scale as f32;
+            let size = 8.0 * scale;
             let hsize = size / 2.0;
             let mut pb = PathBuilder::new();
 
@@ -163,7 +163,7 @@ impl Button {
             &path2,
             &button_icon_paint,
             &Stroke {
-                width: 1.0 * scale as f32,
+                width: 1.0 * scale,
                 ..Default::default()
             },
             Transform::identity(),
@@ -216,7 +216,7 @@ impl Button {
         );
 
         let x_icon = {
-            let size = 3.5 * scale as f32;
+            let size = 3.5 * scale;
             let mut pb = PathBuilder::new();
 
             {
@@ -250,7 +250,7 @@ impl Button {
             &x_icon,
             &button_icon_paint,
             &Stroke {
-                width: 1.1 * scale as f32,
+                width: 1.1 * scale,
                 ..Default::default()
             },
             Transform::identity(),
@@ -340,6 +340,6 @@ impl Buttons {
     }
 
     pub fn scaled_size(&self) -> (u32, u32) {
-        (self.w * self.scale as u32, self.h * self.scale as u32)
+        (self.w * self.scale, self.h * self.scale)
     }
 }

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -198,7 +198,7 @@ fn lmb_press(
 fn lmb_release(pointer_data: &mut PointerUserData, maximized: bool) -> Option<FrameRequest> {
     let lpm_grab = pointer_data.lpm_grab.take();
 
-    let req = match pointer_data.location {
+    match pointer_data.location {
         Location::Button(btn) => {
             if lpm_grab == Some(btn) {
                 let req = match btn {
@@ -219,9 +219,7 @@ fn lmb_release(pointer_data: &mut PointerUserData, maximized: bool) -> Option<Fr
             }
         }
         _ => None,
-    };
-
-    req
+    }
 }
 
 fn rmb_press(pointer_data: &PointerUserData) -> Option<FrameRequest> {

--- a/src/title/font_preference.rs
+++ b/src/title/font_preference.rs
@@ -36,6 +36,11 @@ impl FontPreference {
                     _ => None,
                 }
             }
+            Some((head, tail)) if !head.is_empty() => Some(Self {
+                name: head.into(),
+                style: Some(tail.into()),
+                pt_size: 10.0,
+            }),
             None if !conf.is_empty() => Some(Self {
                 name: conf.into(),
                 style: None,
@@ -75,5 +80,12 @@ fn pref_from_name() {
     let pref = FontPreference::from_name_style_size("Cantarell").unwrap();
     assert_eq!(pref.name, "Cantarell");
     assert_eq!(pref.style, None);
+    assert!((pref.pt_size - 10.0).abs() < f32::EPSILON);
+}
+#[test]
+fn pref_from_multi_name_style() {
+    let pref = FontPreference::from_name_style_size("Foo Bar Baz Bold").unwrap();
+    assert_eq!(pref.name, "Foo Bar Baz");
+    assert_eq!(pref.style, Some("Bold".into()));
     assert!((pref.pt_size - 10.0).abs() < f32::EPSILON);
 }


### PR DESCRIPTION
`ab_glyph` titles will read the system title font using memory mapped buffers instead of reading to heap.

This lowers RAM usage of the since previously the system font would be saved in heap. For some system fonts this can be quite large and undesirable for rendering a title.

The disadvantage is currently the font must be parsed before each use instead of once at startup. It may be possible to improve this later with https://github.com/alexheretic/owned-ttf-parser/issues/11. In any case on my system `render()` time is relatively unaffected at 50-100µs so this doesn't seem a deal breaker.

## Tests
My system title font is Cantarell-VF.otf (167K). Running the `cargo run --example simple --release`
* Before: 570-720K memory
* After: 400-550K memory

If I choose NotoSerifCJK-Bold.ttc (27M). Running the `cargo run --example simple --release`
* Before: 27.8-27.9M memory
* After: 400-550K memory

## Bonus
I've also improved the `FontPreference` parsing so it can handle config like `Noto Serif CJK HK Bold 12` as I noticed that wasn't working properly when I wanted to test it.

Resolves #17 