### PR TITLE
Support custom header buttons layouts

### DIFF
--- a/src/buttons.rs
+++ b/src/buttons.rs
@@ -106,17 +106,11 @@ impl Buttons {
     }
 
     pub fn right_buttons_start_x(&self) -> Option<f32> {
-        match self.buttons_right.last() {
-            Some(button) => Some(button.x()),
-            None => None,
-        }
+        self.buttons_right.last().map(|button| button.x())
     }
 
     pub fn left_buttons_end_x(&self) -> Option<f32> {
-        match self.buttons_left.last() {
-            Some(button) => Some(button.end_x()),
-            None => None,
-        }
+        self.buttons_left.last().map(|button| button.end_x())
     }
 
     pub fn draw(
@@ -147,16 +141,14 @@ impl Buttons {
     }
 
     fn parse_button_layout(sides: Option<(String, String)>) -> Option<ButtonLayout> {
-        if sides.is_none() {
+        let Some((left_side, right_side)) = sides else {
             return None;
-        }
-
-        let (left_side, right_side) = sides.unwrap();
+        };
 
         let buttons_left = Buttons::parse_button_layout_side(left_side, Side::Left);
         let buttons_right = Buttons::parse_button_layout_side(right_side, Side::Right);
 
-        if buttons_left.len() == 0 && buttons_right.len() == 0 {
+        if buttons_left.is_empty() && buttons_right.is_empty() {
             warn!("No valid buttons found in configuration");
             return None;
         }
@@ -167,7 +159,7 @@ impl Buttons {
     fn parse_button_layout_side(config: String, side: Side) -> Vec<Button> {
         let mut buttons: Vec<Button> = vec![];
 
-        for button in config.split(",").take(3) {
+        for button in config.split(',').take(3) {
             let button_kind = match button {
                 "close" => Some(ButtonKind::Close),
                 "maximize" => Some(ButtonKind::Maximize),
@@ -175,22 +167,19 @@ impl Buttons {
                 _ => None,
             };
 
-            if button_kind.is_none() {
+            let Some(kind) = button_kind else {
                 warn!("Found unknown button type, ignoring");
                 continue;
-            }
-            let kind = button_kind.unwrap();
+            };
             buttons.push(Button::new(kind));
         }
 
         // For the right side, we need to revert the order
-        let buttons = if side == Side::Right {
+        if side == Side::Right {
             buttons.into_iter().rev().collect()
         } else {
             buttons
-        };
-
-        buttons
+        }
     }
 
     fn get_default_buttons_layout() -> ButtonLayout {

--- a/src/buttons.rs
+++ b/src/buttons.rs
@@ -1,3 +1,4 @@
+use log::warn;
 use tiny_skia::{FillRule, PathBuilder, PixmapMut, Rect, Stroke, Transform};
 
 use smithay_client_toolkit::shell::xdg::window::{WindowManagerCapabilities, WindowState};
@@ -11,42 +12,59 @@ const BUTTON_SPACING: f32 = 13.;
 
 #[derive(Debug)]
 pub(crate) struct Buttons {
-    pub close: Button,
-    pub maximize: Option<Button>,
-    pub minimize: Option<Button>,
+    // Sorted by order vec of buttons for the left and right sides
+    buttons_left: Vec<Button>,
+    buttons_right: Vec<Button>,
+    layout_config: Option<(String, String)>,
 }
+
+type ButtonLayout = (Vec<Button>, Vec<Button>);
 
 impl Default for Buttons {
     fn default() -> Self {
+        let (buttons_left, buttons_right) = Buttons::get_default_buttons_layout();
+
         Self {
-            close: Button::new(ButtonKind::Close),
-            maximize: Some(Button::new(ButtonKind::Maximize)),
-            minimize: Some(Button::new(ButtonKind::Minimize)),
+            buttons_left,
+            buttons_right,
+            layout_config: None,
         }
     }
 }
 
 impl Buttons {
+    pub fn new(layout_config: Option<(String, String)>) -> Self {
+        match Buttons::parse_button_layout(layout_config.clone()) {
+            Some((buttons_left, buttons_right)) => Self {
+                buttons_left,
+                buttons_right,
+                layout_config,
+            },
+            _ => Self::default(),
+        }
+    }
+
     /// Rearrange the buttons with the new width.
-    pub fn arrange(&mut self, width: u32) {
-        let mut x = width as f32 - BUTTON_MARGIN;
+    pub fn arrange(&mut self, width: u32, margin_h: f32) {
+        let mut left_x = BUTTON_MARGIN + margin_h;
+        let mut right_x = width as f32 - BUTTON_MARGIN;
 
-        for button in [
-            Some(&mut self.close),
-            self.maximize.as_mut(),
-            self.minimize.as_mut(),
-        ]
-        .into_iter()
-        .flatten()
-        {
+        for button in &mut self.buttons_left {
+            button.offset = left_x;
+
+            // Add the button size plus spacing
+            left_x += BUTTON_SIZE + BUTTON_SPACING;
+        }
+
+        for button in &mut self.buttons_right {
             // Subtract the button size.
-            x -= BUTTON_SIZE;
+            right_x -= BUTTON_SIZE;
 
-            // Update it's
-            button.offset = x;
+            // Update it
+            button.offset = right_x;
 
             // Subtract spacing for the next button.
-            x -= BUTTON_SPACING;
+            right_x -= BUTTON_SPACING;
         }
     }
 
@@ -54,43 +72,136 @@ impl Buttons {
     pub fn find_button(&self, x: f64, y: f64) -> Location {
         let x = x as f32;
         let y = y as f32;
-        if self.close.contains(x, y) {
-            Location::Button(ButtonKind::Close)
-        } else if self.maximize.as_ref().map(|b| b.contains(x, y)) == Some(true) {
-            Location::Button(ButtonKind::Maximize)
-        } else if self.minimize.as_ref().map(|b| b.contains(x, y)) == Some(true) {
-            Location::Button(ButtonKind::Minimize)
-        } else {
-            Location::Head
+        let buttons = self.buttons_left.iter().chain(self.buttons_right.iter());
+
+        for button in buttons {
+            if button.contains(x, y) {
+                return Location::Button(button.kind);
+            }
+        }
+
+        Location::Head
+    }
+
+    pub fn update_wm_capabilities(&mut self, wm_capabilites: WindowManagerCapabilities) {
+        let supports_maximize = wm_capabilites.contains(WindowManagerCapabilities::MAXIMIZE);
+        let supports_minimize = wm_capabilites.contains(WindowManagerCapabilities::MINIMIZE);
+
+        self.update_buttons(supports_maximize, supports_minimize);
+    }
+
+    pub fn update_buttons(&mut self, supports_maximize: bool, supports_minimize: bool) {
+        let is_supported = |button: &Button| match button.kind {
+            ButtonKind::Close => true,
+            ButtonKind::Maximize => supports_maximize,
+            ButtonKind::Minimize => supports_minimize,
+        };
+
+        let (buttons_left, buttons_right) =
+            Buttons::parse_button_layout(self.layout_config.clone())
+                .unwrap_or_else(Buttons::get_default_buttons_layout);
+
+        self.buttons_left = buttons_left.into_iter().filter(is_supported).collect();
+        self.buttons_right = buttons_right.into_iter().filter(is_supported).collect();
+    }
+
+    pub fn right_buttons_start_x(&self) -> Option<f32> {
+        match self.buttons_right.last() {
+            Some(button) => Some(button.x()),
+            None => None,
         }
     }
 
-    pub fn update(&mut self, wm_capabilites: WindowManagerCapabilities) {
-        self.maximize = wm_capabilites
-            .contains(WindowManagerCapabilities::MAXIMIZE)
-            .then_some(Button::new(ButtonKind::Maximize));
-        self.minimize = wm_capabilites
-            .contains(WindowManagerCapabilities::MINIMIZE)
-            .then_some(Button::new(ButtonKind::Minimize));
-    }
-
-    pub fn left_most(&self) -> &Button {
-        if let Some(minimize) = self.minimize.as_ref() {
-            minimize
-        } else if let Some(maximize) = self.maximize.as_ref() {
-            maximize
-        } else {
-            &self.close
+    pub fn left_buttons_end_x(&self) -> Option<f32> {
+        match self.buttons_left.last() {
+            Some(button) => Some(button.end_x()),
+            None => None,
         }
     }
 
-    pub fn iter(&self) -> std::array::IntoIter<Option<Button>, 3> {
-        [
-            Some(self.close.clone()),
-            self.maximize.clone(),
-            self.minimize.clone(),
-        ]
-        .into_iter()
+    pub fn draw(
+        &self,
+        start_x: f32,
+        end_x: f32,
+        scale: f32,
+        colors: &ColorMap,
+        mouse_location: Location,
+        pixmap: &mut PixmapMut,
+        resizable: bool,
+        state: &WindowState,
+    ) {
+        let left_buttons_right_limit =
+            self.right_buttons_start_x().unwrap_or(end_x).min(end_x) - BUTTON_SPACING;
+        let buttons_left = self.buttons_left.iter().map(|x| (x, Side::Left));
+        let buttons_right = self.buttons_right.iter().map(|x| (x, Side::Right));
+
+        for (button, side) in buttons_left.chain(buttons_right) {
+            let is_visible = button.x() > start_x && button.end_x() < end_x
+                // If we have buttons from both sides and they overlap, prefer the right side
+                && (side == Side::Right || button.end_x() < left_buttons_right_limit);
+
+            if is_visible {
+                button.draw(scale, colors, mouse_location, pixmap, resizable, state);
+            }
+        }
+    }
+
+    fn parse_button_layout(sides: Option<(String, String)>) -> Option<ButtonLayout> {
+        if sides.is_none() {
+            return None;
+        }
+
+        let (left_side, right_side) = sides.unwrap();
+
+        let buttons_left = Buttons::parse_button_layout_side(left_side, Side::Left);
+        let buttons_right = Buttons::parse_button_layout_side(right_side, Side::Right);
+
+        if buttons_left.len() == 0 && buttons_right.len() == 0 {
+            warn!("No valid buttons found in configuration");
+            return None;
+        }
+
+        Some((buttons_left, buttons_right))
+    }
+
+    fn parse_button_layout_side(config: String, side: Side) -> Vec<Button> {
+        let mut buttons: Vec<Button> = vec![];
+
+        for button in config.split(",").take(3) {
+            let button_kind = match button {
+                "close" => Some(ButtonKind::Close),
+                "maximize" => Some(ButtonKind::Maximize),
+                "minimize" => Some(ButtonKind::Minimize),
+                _ => None,
+            };
+
+            if button_kind.is_none() {
+                warn!("Found unknown button type, ignoring");
+                continue;
+            }
+            let kind = button_kind.unwrap();
+            buttons.push(Button::new(kind));
+        }
+
+        // For the right side, we need to revert the order
+        let buttons = if side == Side::Right {
+            buttons.into_iter().rev().collect()
+        } else {
+            buttons
+        };
+
+        buttons
+    }
+
+    fn get_default_buttons_layout() -> ButtonLayout {
+        (
+            vec![],
+            vec![
+                Button::new(ButtonKind::Close),
+                Button::new(ButtonKind::Maximize),
+                Button::new(ButtonKind::Minimize),
+            ],
+        )
     }
 }
 
@@ -121,6 +232,10 @@ impl Button {
 
     pub fn center_y(&self) -> f32 {
         BUTTON_MARGIN + self.radius()
+    }
+
+    pub fn end_x(&self) -> f32 {
+        self.offset + BUTTON_SIZE
     }
 
     fn contains(&self, x: f32, y: f32) -> bool {
@@ -264,4 +379,10 @@ pub enum ButtonKind {
     Close,
     Maximize,
     Minimize,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Side {
+    Left,
+    Right,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,10 +43,10 @@ pub(crate) fn get_button_layout_config() -> Option<(String, String)> {
 
     let sides_split: Vec<_> = config_string
         // Taking last word
-        .rsplit(" ")
-        .nth(0)?
+        .rsplit(' ')
+        .next()?
         // Split by left/right side
-        .split(":")
+        .split(':')
         // Only two sides
         .take(2)
         .collect();

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,9 +37,7 @@ pub(crate) fn get_button_layout_config() -> Option<(String, String)> {
         .arg("string:button-layout")
         .output()
         .ok()
-        .and_then(|out| String::from_utf8(out.stdout).ok());
-
-    let config_string = config_string.unwrap();
+        .and_then(|out| String::from_utf8(out.stdout).ok())?;
 
     let sides_split: Vec<_> = config_string
         // Taking last word

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,7 +341,8 @@ where
             .expect("trying to resize the hidden frame.");
 
         decorations.resize(width.get(), height.get());
-        self.buttons.arrange(width.get(), get_margin_h_lp(&self.state));
+        self.buttons
+            .arrange(width.get(), get_margin_h_lp(&self.state));
         self.dirty = true;
     }
 
@@ -517,7 +518,6 @@ fn draw_headerbar(
             let (x, y, text_canvas_start_x) = if (x + text_w < right_buttons_start_x - offset_x)
                 && (x > left_buttons_end_x + offset_x)
             {
-                dbg!(x, y, text_w, right_buttons_start_x);
                 let text_canvas_start_x = x;
 
                 (x, y, text_canvas_start_x)


### PR DESCRIPTION
Closes https://github.com/PolyMeilex/sctk-adwaita/issues/27

In this MR I've generalized the button structure and it is now possible to have custom layouts in window headers similar to what you can have in Gnome apps or classic Xorg WMs.

Obvious use case for this would be to have buttons moved to the left side (like Unity):
![Screenshot from 2023-06-02 17-48-45](https://github.com/PolyMeilex/sctk-adwaita/assets/5887089/ec27c07d-1681-4744-b1b7-ef8e21e12c96)

But other possible layout combinations should work, too:
![Screenshot from 2023-06-02 17-51-02](https://github.com/PolyMeilex/sctk-adwaita/assets/5887089/614d55a8-17eb-4d03-9360-28861dc6bc14)
or even something crazy like
![Screenshot from 2023-06-02 17-52-01](https://github.com/PolyMeilex/sctk-adwaita/assets/5887089/9653711a-b8c0-40f9-9c67-b4b90be1958d)

Also should be extendable if we will (ever) have an app menu button.

I didn't have any experience in rust so far, thus feedback is more than welcomed.