### PR TITLE
Raise double click threshold to 400ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- The double click threshold value was raised to `400ms`
+
 ## 0.6.0
 - Update the `smithay-client-toolkit` to `0.17.0`
 - Don't use tiny-skia's default features

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -14,7 +14,9 @@ use crate::{
 };
 
 /// Time to register the next click as a double click.
-const DOUBLE_CLICK_DURATION: Duration = Duration::from_millis(300);
+///
+/// The value is the same as the default in gtk4.
+const DOUBLE_CLICK_DURATION: Duration = Duration::from_millis(400);
 
 /// The state of the mouse input inside the decorations frame.
 #[derive(Debug, Default)]


### PR DESCRIPTION
This should improve the situation with some touchpads. GTK4 is also using the same value.