### PR TITLE
Fix transparency in ab_glyph renderer

### DIFF
--- a/src/title/ab_glyph_renderer.rs
+++ b/src/title/ab_glyph_renderer.rs
@@ -93,6 +93,10 @@ impl AbGlyphTitleText {
                 let left = bounds.min.x as u32;
                 let top = bounds.min.y as u32;
                 outline.draw(|x, y, c| {
+                    // `ab_glyph` may return values greater than 1.0, but they are defined to be
+                    // same as 1.0. For our purposes, we need to contrain this value.
+                    let c = c.min(1.0);
+
                     let p_idx = (top + y) * width + (left + x);
                     let old_alpha_u8 = pixels[p_idx as usize].alpha();
                     let new_alpha = c + (old_alpha_u8 as f32 / 255.0);


### PR DESCRIPTION
The `ab_glyph` documentation states:

> A coverage value of 0.0 means the pixel is totally uncoverred by the glyph. A value of 1.0 or greater means fully coverred.

On my machine, this currently results in too high of a alpha value in "self-overlapping" areas, as is especially noticeable in the 'x' and 't' in the following screenshot:

![image](https://github.com/PolyMeilex/sctk-adwaita/assets/20155479/c960d537-3776-4621-8f83-6dc4cc4fc1e5)

This PR makes it look correct:

![image](https://github.com/PolyMeilex/sctk-adwaita/assets/20155479/d04b05f5-ae5f-4d12-9ebd-c3e16d006702)
