### PR TITLE
Fix leftmost title pixel sometimes being cut off

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -589,7 +589,7 @@ fn draw_headerbar(
                         Transform::identity(),
                     );
                     pixmap.draw_pixmap(
-                        x as i32,
+                        x.round() as i32,
                         y as i32,
                         text_pixmap.as_ref(),
                         &PixmapPaint::default(),


### PR DESCRIPTION
When centering the title text in an window of even width, the leftmost pixel of the title text is being cut off. This is because the clip rect is positioned according to x as a floating point, but the pixmap is positioned according to x as cast to an integer. Casting a float to an int floors it.

For example when x is `100.5`, the mask will start at x `100.5`, but the pixmap will be drawn at x `100`, so a bit of the title text will be cut off.

This is noticeable in the following recording, which shows the window being slowly resized. Focus on the bottom-left of the first "/".

[Screencast from 2023-11-10 20-44-40.webm](https://github.com/PolyMeilex/sctk-adwaita/assets/20155479/589b828c-b967-4842-a175-4ce5897ce1c2)
