### PR TITLE
Extended resize corners

### DIFF
--- a/src/parts.rs
+++ b/src/parts.rs
@@ -126,6 +126,10 @@ impl DecorationParts {
         &self.parts[Self::HEADER]
     }
 
+    pub fn side_height(&self) -> u32 {
+        self.parts[Self::LEFT].height
+    }
+
     pub fn find_surface(&self, surface: &ObjectId) -> Location {
         let pos = match self
             .parts

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,7 +1,11 @@
 pub use tiny_skia::Color;
 use tiny_skia::{Paint, Shader};
 
-pub(crate) const BORDER_SIZE: u32 = 10;
+// https://gitlab.gnome.org/GNOME/gtk/-/blob/1bf88f1d81043fd99740e2f91e56ade7ede7303b/gtk/gtkwindow.c#L165
+pub(crate) const RESIZE_HANDLE_SIZE: u32 = 12;
+// https://gitlab.gnome.org/GNOME/gtk/-/blob/1bf88f1d81043fd99740e2f91e56ade7ede7303b/gtk/gtkwindow.c#L166
+pub(crate) const RESIZE_HANDLE_CORNER_SIZE: u32 = 24;
+pub(crate) const BORDER_SIZE: u32 = VISIBLE_BORDER_SIZE + RESIZE_HANDLE_SIZE;
 pub(crate) const HEADER_SIZE: u32 = 35;
 pub(crate) const CORNER_RADIUS: u32 = 10;
 pub(crate) const VISIBLE_BORDER_SIZE: u32 = 1;


### PR DESCRIPTION
This changed can best be explained using these videos:

[Screencast from 2023-11-25 23-42-04.webm](https://github.com/PolyMeilex/sctk-adwaita/assets/20155479/99f1a030-03fd-4659-afbe-a46639fb7d6b)

[Screencast from 2023-11-25 23-42-54.webm](https://github.com/PolyMeilex/sctk-adwaita/assets/20155479/ec0a4ca9-bc70-4fe4-a854-77fc2488cb05)

Essentially, when resizing, the corner resize region is enlarged. This resolves a parity issue with GTK. The values were directly taken from the GTK source code, as per the comments above the constants.