### PR TITLE
Surround the ab_glyph pixmap with a 1px border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## [Unreleased]
 
+- Fix `ab_glyph` renderer panicking with integer scale factor 3 (#50)
 - Improved roundness of headerbar (#51)
 
 ## 0.8.0
-- **Braking:** `AdwaitaFrame::new` now takes `Arc<CompositorState>` as an argument
+- **Breaking:** `AdwaitaFrame::new` now takes `Arc<CompositorState>` as an argument
 - Fix leftmost title pixel sometimes being cut off (#45)
 - Fix transparency in ab_glyph renderer (#44)
 - Extended resize corners (#47)

--- a/src/title/ab_glyph_renderer.rs
+++ b/src/title/ab_glyph_renderer.rs
@@ -80,8 +80,8 @@ impl AbGlyphTitleText {
 
         let glyphs = self.layout(&font);
         let last_glyph = glyphs.last()?;
-        let width = (last_glyph.position.x + font.h_advance(last_glyph.id)).ceil() as u32;
-        let height = font.height().ceil() as u32;
+        let width = (last_glyph.position.x + font.h_advance(last_glyph.id)).ceil() as u32 + 2;
+        let height = font.height().ceil() as u32 + 2;
 
         let mut pixmap = Pixmap::new(width, height)?;
 
@@ -97,7 +97,7 @@ impl AbGlyphTitleText {
                     // same as 1.0. For our purposes, we need to contrain this value.
                     let c = c.min(1.0);
 
-                    let p_idx = (top + y) * width + (left + x);
+                    let p_idx = (top + y + 1) * width + (left + x + 1);
                     let old_alpha_u8 = pixels[p_idx as usize].alpha();
                     let new_alpha = c + (old_alpha_u8 as f32 / 255.0);
                     if let Some(px) = PremultipliedColorU8::from_rgba(

--- a/src/title/ab_glyph_renderer.rs
+++ b/src/title/ab_glyph_renderer.rs
@@ -80,6 +80,8 @@ impl AbGlyphTitleText {
 
         let glyphs = self.layout(&font);
         let last_glyph = glyphs.last()?;
+        // + 2 because ab_glyph likes to draw outside of its area,
+        // so we add 1px border around the pixmap
         let width = (last_glyph.position.x + font.h_advance(last_glyph.id)).ceil() as u32 + 2;
         let height = font.height().ceil() as u32 + 2;
 
@@ -97,6 +99,7 @@ impl AbGlyphTitleText {
                     // same as 1.0. For our purposes, we need to contrain this value.
                     let c = c.min(1.0);
 
+                    // offset the index by 1, so it is in the center of the pixmap
                     let p_idx = (top + y + 1) * width + (left + x + 1);
                     let old_alpha_u8 = pixels[p_idx as usize].alpha();
                     let new_alpha = c + (old_alpha_u8 as f32 / 255.0);


### PR DESCRIPTION
ab_glyph apparently likes to draw outside of its area in some cases.

Fixes #50