### PR TITLE
Bump crossfont to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,7 @@ tiny-skia = { version = "0.11", default-features = false, features = [
 smithay-client-toolkit = { version = "0.18.0", default_features = false }
 
 # Draw title text using crossfont `--features crossfont`
-crossfont = { version = "0.7.0", features = [
-  "force_system_fontconfig",
-], optional = true }
+crossfont = { version = "0.8.0", optional = true }
 # Draw title text using ab_glyph `--features ab_glyph`
 ab_glyph = { version = "0.2.17", optional = true }
 


### PR DESCRIPTION
This switches the underlying fontconfig-sys crate to yeslogic-fontconfig-sys, due to Servo's lack of maintenance.