### PR TITLE
Bump sctk dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ tiny-skia = { version = "0.11", default-features = false, features = [
   "std",
   "simd",
 ] }
-smithay-client-toolkit = { version = "0.18.0", default_features = false }
+smithay-client-toolkit = { version = "0.19.0", default_features = false }
 
 # Draw title text using crossfont `--features crossfont`
 crossfont = { version = "0.8.0", optional = true }


### PR DESCRIPTION
I think types from sctk are used in the public API, so this will probably also require a major version bump for this crate?