### PR TITLE
Improve ab-glyph rendering use outline px_bounds to inform pixmap size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Improve `ab_glyph` rendering to properly account for glyph outlines that would have previously been out of bounds
 
 ## 0.10.1
 - Panic hardening of ab-glyph (#64)


### PR DESCRIPTION
I saw there were some recent issues with oob on the pixmap when rendering using _ab_glyph_.

The root cause is the use of "layout" positions (font.height(), h_advance etc) to inform the actual rendering pixmap size. The sizes for laying out glyphs are not always the same as the bounds required for actually rendering the glyphs. For example, a glyph at x=0 may have an outline/render that actually includes some pixels to the left of that layout origin.

ab-glyph provides [`OutlinedGlyph::px_bounds`](https://docs.rs/ab_glyph/latest/ab_glyph/struct.OutlinedGlyph.html#method.px_bounds) which accounts for this and will always have enough space to render each pixel returned by [`OutlinedGlyph::draw`](https://docs.rs/ab_glyph/latest/ab_glyph/struct.OutlinedGlyph.html#method.draw) correctly. Continuing the example where the glyph (at x=0) outline reaches out to the left of the origin, the `px_bounds.min.x` of that glyph would be _negative_.

So outlining the glyphs and using px_bounds gives the correct pixmap size. It is then important to convert the px_bounds into "pixmap space" when calculating the pixel index, since px_bounds.min.x may be non-zero. I added comments to explain this in the code.

After all that we should end up with smaller pixmaps than before and `p_idx` should never go oob. _(The pixmaps could be even smaller actually, I padding the vertical size with the full "ascent" of the font just to make positioning of the pixmap consistent e.g. so "Tg" & "gg" would have the same height pixmap)._

I replaced the log with a debug_assert, since it "should never happen" but if a bug is still there or is introduced we'd probably prefer release code to still not panic.

Please feel free to ping me directly if you have problems/questions about _ab_glyph_ code in future.