### PR TITLE
Add ability to hide the titlebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 - Improve `ab_glyph` rendering to properly account for glyph outlines that would have previously been out of bounds
+- Align with new adwaita blue tint #71
+- Add ability to hide the titlebar #69 
 
 ## 0.10.1
 - Panic hardening of ab-glyph (#64)


### PR DESCRIPTION
Add ability to draw only the window frame, for those who are too lazy to draw decorations themselves but want to implement a custom headerbar (aka. me):

![hide-titlebar](https://github.com/user-attachments/assets/7b335c88-d7ba-4e02-9c6a-8ae0ff66644c)
