### PR TITLE
Add the option to hide the borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Add the option to hide the borders `FrameConfig::hide_border`
 
 ## 0.11.0
 - Improve `ab_glyph` rendering to properly account for glyph outlines that would have previously been out of bounds

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -101,6 +101,7 @@ fn main() {
         set_cursor: false,
         cursor_icon: CursorIcon::Crosshair,
         hide_titlebar: false,
+        hide_border: false,
     };
 
     // We don't draw immediately, the configure will notify us when to first draw.
@@ -139,6 +140,7 @@ struct SimpleWindow {
     cursor_icon: CursorIcon,
 
     hide_titlebar: bool,
+    hide_border: bool,
 }
 
 impl CompositorHandler for SimpleWindow {
@@ -456,7 +458,7 @@ impl PointerHandler for SimpleWindow {
 
                             if let Some(frame) = self.window_frame.as_mut() {
                                 // FrameConfig::auto() is not free, this shouldn't be called here
-                                let config = FrameConfig::auto();
+                                let config = FrameConfig::auto().hide_border(self.hide_border);
 
                                 if self.hide_titlebar {
                                     frame.set_config(config.hide_titlebar(true));
@@ -485,6 +487,14 @@ impl PointerHandler for SimpleWindow {
                                     self.width = width;
                                     self.height = height;
                                 }
+                            }
+                        } else if button == 0x112 {
+                            if let Some(frame) = self.window_frame.as_mut() {
+                                // FrameConfig::auto() is not free, this shouldn't be called here
+                                let config = FrameConfig::auto().hide_titlebar(self.hide_titlebar);
+
+                                self.hide_border = !self.hide_border;
+                                frame.set_config(config.hide_border(self.hide_border));
                             }
                         } else {
                             self.shift = self.shift.xor(Some(0));
@@ -602,6 +612,7 @@ impl SimpleWindow {
                     let g = u32::min((x * 0xFF) / width, ((height - y) * 0xFF) / height);
                     let b = u32::min(((width - x) * 0xFF) / width, (y * 0xFF) / height);
                     let color = (a << 24) + (r << 16) + (g << 8) + b;
+                    // let color: u32 = 0x0;
 
                     let array: &mut [u8; 4] = chunk.try_into().unwrap();
                     *array = color.to_le_bytes();

--- a/src/parts.rs
+++ b/src/parts.rs
@@ -14,7 +14,7 @@ use smithay_client_toolkit::{
     subcompositor::{SubcompositorState, SubsurfaceData},
 };
 
-use crate::theme::{BORDER_SIZE, HEADER_SIZE, RESIZE_HANDLE_SIZE};
+use crate::theme::{self, HEADER_SIZE, RESIZE_HANDLE_SIZE};
 use crate::{pointer::Location, wl_typed::WlTyped};
 
 /// The decoration's 'parts'.
@@ -59,7 +59,8 @@ impl DecorationParts {
         self.parts.iter_mut().enumerate()
     }
 
-    pub fn borders_mut(&mut self) -> impl Iterator<Item = &mut Part> {
+    /// Edge is a border + shadow
+    fn edges_mut(&mut self) -> impl Iterator<Item = &mut Part> {
         self.parts_mut()
             .filter(|(idx, _)| *idx != Self::HEADER)
             .map(|(_, p)| p)
@@ -88,8 +89,9 @@ impl DecorationParts {
         }
     }
 
-    pub fn hide_borders(&mut self) {
-        for part in self.borders_mut() {
+    /// Edge is a border + shadow
+    pub fn hide_edges(&mut self) {
+        for part in self.edges_mut() {
             part.hide = true;
             part.surface.attach(None, 0, 0);
             part.surface.commit();
@@ -103,11 +105,11 @@ impl DecorationParts {
         part.surface.commit();
     }
 
-    pub fn resize(&mut self, width: u32, height: u32, hide_titlebar: bool) {
+    pub fn resize(&mut self, width: u32, height: u32, hide_titlebar: bool, hide_border: bool) {
         let header_size = if hide_titlebar { 0 } else { HEADER_SIZE };
         let height_with_header = height + header_size;
 
-        let border_size = BORDER_SIZE;
+        let border_size = theme::border_size(hide_border);
 
         let width_with_border = width + 2 * border_size;
         let width_input_rect = width_with_border - (border_size * 2) + (RESIZE_HANDLE_SIZE * 2);

--- a/src/pointer.rs
+++ b/src/pointer.rs
@@ -6,7 +6,7 @@ use smithay_client_toolkit::reexports::csd_frame::{
 
 use crate::{
     buttons::ButtonKind,
-    theme::{BORDER_SIZE, HEADER_SIZE},
+    theme::{self, HEADER_SIZE},
 };
 
 /// Time to register the next click as a double click.
@@ -80,9 +80,12 @@ impl MouseState {
         &mut self,
         pressed: bool,
         wm_capabilities: &WindowManagerCapabilities,
+        hide_border: bool,
     ) -> Option<FrameAction> {
         // Invalidate the normal click.
         self.last_normal_click = None;
+
+        let border_size = theme::border_size(hide_border);
 
         match self.location {
             Location::Head | Location::Button(_)
@@ -91,7 +94,7 @@ impl MouseState {
                 Some(FrameAction::ShowMenu(
                     // XXX this could be one 1pt off when the frame is not maximized, but it's not
                     // like it really matters in the end.
-                    self.position.0 as i32 - BORDER_SIZE as i32,
+                    self.position.0 as i32 - border_size as i32,
                     // We must offset it by header size for precise position.
                     self.position.1 as i32 - HEADER_SIZE as i32,
                 ))

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -5,10 +5,20 @@ use tiny_skia::{Paint, Shader};
 pub(crate) const RESIZE_HANDLE_SIZE: u32 = 12;
 // https://gitlab.gnome.org/GNOME/gtk/-/blob/1bf88f1d81043fd99740e2f91e56ade7ede7303b/gtk/gtkwindow.c#L166
 pub(crate) const RESIZE_HANDLE_CORNER_SIZE: u32 = 24;
-pub(crate) const BORDER_SIZE: u32 = crate::shadow::SHADOW_SIZE + VISIBLE_BORDER_SIZE;
 pub(crate) const HEADER_SIZE: u32 = 35;
 pub(crate) const CORNER_RADIUS: u32 = 10;
-pub(crate) const VISIBLE_BORDER_SIZE: u32 = 1;
+
+pub(crate) fn border_size(hide_border: bool) -> u32 {
+    crate::shadow::SHADOW_SIZE + visible_border_size(hide_border)
+}
+
+pub(crate) fn visible_border_size(hide_border: bool) -> u32 {
+    if hide_border {
+        0
+    } else {
+        1
+    }
+}
 
 /// The color theme to use with the decorations frame.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Can be tested by using the middle mouse button in the example (it flickers when changing the mode, that will be addressed latter).

<img width="328" height="325" alt="image" src="https://github.com/user-attachments/assets/8bd10d81-bdf5-4bb1-a21a-3406c1a46538" />
<img width="328" height="325" alt="image" src="https://github.com/user-attachments/assets/918d0e7b-078d-40e4-b271-0d8cc92b1124" />

closes #78