### PR TITLE
perf: optimize wayland decoration rendering and cpu usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,7 +339,7 @@ where
                 };
             }
 
-            if should_sync {
+            if false {
                 part.subsurface.set_sync();
             } else {
                 part.subsurface.set_desync();
@@ -437,6 +437,9 @@ where
     }
 
     fn draw(&mut self) -> bool {
+        if !self.dirty {
+            return false;
+        }
         self.redraw_inner().unwrap_or(true)
     }
 


### PR DESCRIPTION
This PR introduces two critical performance optimizations for Wayland rendering:

1. **Dirty Check in `draw()`:** Prevents redundant software rendering loops. The CPU was previously recalculating boundaries and recopying shadow/border pixel buffers even when the window frame hadn't moved or changed state, causing massive CPU overhead.
2. **Decoupled Subsurface Sync:** Unconditionally sets `part.subsurface.set_desync()`. Previously, Wayland composite surfaces were forced to sync their presentation with the slow software-rendered border frames, which injected significant artificial latency into high-FPS OpenGL/WGPU application surfaces during resize or movement. Decoupling them allows the primary application surface to render unblocked at native speeds.