### PR TITLE
skrifa: set wght=700 axis for bold font preference

### DIFF
--- a/src/title/skrifa_renderer.rs
+++ b/src/title/skrifa_renderer.rs
@@ -6,9 +6,9 @@
 //! if the system font doesn't work.
 use crate::title::{config, font_preference::FontPreference};
 use skrifa::{
-    instance::{LocationRef, Size},
+    instance::{Location, LocationRef, Size},
     outline::{DrawSettings, HintingInstance, HintingOptions, OutlinePen},
-    MetadataProvider,
+    MetadataProvider, Tag,
 };
 use std::{fs::File, process::Command};
 use tiny_skia::{Color, FillRule, Paint, Pixmap, Transform};
@@ -79,8 +79,17 @@ impl SkrifaTitleText {
         }
 
         let font = parse_font(&self.font);
+        let font_pref = self.font.as_ref().map(|(_, pref)| pref);
         let size = Size::new(self.px_size);
-        let location = LocationRef::default();
+        let is_bold = font_pref
+            .and_then(|p| p.style.as_deref())
+            .is_some_and(|s| s.eq_ignore_ascii_case("bold"));
+        let location_storage = if is_bold {
+            font.axes().location([(Tag::new(b"wght"), 700.0f32)])
+        } else {
+            Location::default()
+        };
+        let location = LocationRef::from(&location_storage);
 
         let metrics = font.metrics(size, location);
         let glyph_metrics = font.glyph_metrics(size, location);


### PR DESCRIPTION
Post-last-minute addendum to https://github.com/PolyMeilex/sctk-adwaita/pull/91 - sorry.
I just noticed on the screenshot in there that text looked a bit thin. Now it matches really closely with the other two backends.

This might not be worth its own CHANGELOG entry.

> Mirrors the ab_glyph backend's bold handling: when the font preference style is "bold" (case-insensitive), build a variation Location with the wght axis set to 700 instead of using the default empty location. This applies the weight to metrics, glyph advances, hinting, and outline drawing. For non-variable fonts the extra axis coord is a no-op.