### PR TITLE
ci: Add skrifa-build job to the testing GHA workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,6 +84,22 @@ jobs:
           command: build
           args: --no-default-features --features crossfont
 
+  skrifa-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --no-default-features --features skrifa
+
   ab-glyph-build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Another tack-on to https://github.com/PolyMeilex/sctk-adwaita/pull/91.
Just to make sure it doesn't break in the future.
Basically copied the ab_glyph job.
And then I'll stop with the PR spam, I promise... :face_with_peeking_eye: