### PR TITLE
Title text: fontconfig fallback for codepoints outside the primary font

### DIFF
--- a/src/title.rs
+++ b/src/title.rs
@@ -2,6 +2,8 @@ use tiny_skia::{Color, Pixmap};
 
 #[cfg(any(feature = "crossfont", feature = "skrifa", feature = "ab_glyph"))]
 mod config;
+#[cfg(any(feature = "skrifa", feature = "ab_glyph"))]
+mod font_fallback;
 #[cfg(any(feature = "crossfont", feature = "skrifa", feature = "ab_glyph"))]
 mod font_preference;
 

--- a/src/title/ab_glyph_renderer.rs
+++ b/src/title/ab_glyph_renderer.rs
@@ -4,7 +4,10 @@
 //!
 //! Can fallback to a embedded Cantarell-Regular.ttf font (SIL Open Font Licence v1.1)
 //! if the system font doesn't work.
-use crate::title::{config, font_preference::FontPreference};
+//!
+//! Per-codepoint fallback faces (emoji, CJK, …) are discovered via `fc-match`;
+//! see [`crate::title::font_fallback`].
+use crate::title::{config, font_fallback::FallbackCache, font_preference::FontPreference};
 use ab_glyph::{point, Font, FontRef, Glyph, PxScale, PxScaleFont, ScaleFont, VariableFont};
 use std::{fs::File, process::Command};
 use tiny_skia::{Color, Pixmap, PremultipliedColorU8};
@@ -15,6 +18,7 @@ const CANTARELL: &[u8] = include_bytes!("Cantarell-Regular.ttf");
 pub struct AbGlyphTitleText {
     title: String,
     font: Option<(memmap2::Mmap, FontPreference)>,
+    fallbacks: FallbackCache,
     original_px_size: f32,
     size: PxScale,
     color: Color,
@@ -39,6 +43,7 @@ impl AbGlyphTitleText {
         Self {
             title: <_>::default(),
             font,
+            fallbacks: FallbackCache::default(),
             original_px_size: size.x,
             size,
             color,
@@ -58,6 +63,7 @@ impl AbGlyphTitleText {
         let new_title = title.into();
         if new_title != self.title {
             self.title = new_title;
+            self.discover_fallbacks();
             self.pixmap = self.render();
         }
     }
@@ -73,97 +79,150 @@ impl AbGlyphTitleText {
         self.pixmap.as_ref()
     }
 
+    /// Load additional faces for any title codepoint not covered by the primary
+    /// font or any previously-loaded fallback.
+    fn discover_fallbacks(&mut self) {
+        let primary = parse_font(&self.font);
+        self.fallbacks.extend(&self.title, |c, loaded| {
+            covers(&primary, c)
+                || loaded
+                    .iter()
+                    .any(|m| FontRef::try_from_slice(m).is_ok_and(|fr| covers(&fr, c)))
+        });
+    }
+
     /// Render returning the new `Pixmap`.
     fn render(&self) -> Option<Pixmap> {
-        let font = parse_font(&self.font);
-        let font = font.as_scaled(self.size);
-
-        let glyphs: Vec<_> = self
-            .layout(&font)
-            .into_iter()
-            .filter_map(|g| font.outline_glyph(g))
+        let primary = parse_font(&self.font).into_scaled(self.size);
+        let fallbacks: Vec<_> = self
+            .fallbacks
+            .fonts
+            .iter()
+            .filter_map(|m| FontRef::try_from_slice(m).ok())
+            .map(|fr| fr.into_scaled(self.size))
             .collect();
 
-        // calc combined px bound coordinates of the rendered glyphs
-        // Note: It is possible for min.x to be negative, e.g. the first glyph's
-        //       outline extends a little out to the left further than the layout x origin 0.0
-        let all_px_bounds = glyphs.iter().map(|g| g.px_bounds()).reduce(|mut b, next| {
-            b.min.x = b.min.x.min(next.min.x);
-            b.max.x = b.max.x.max(next.max.x);
-            // min(0.0): consistently allocate enough for the whole ascent even
-            //           if all glyphs don't need that much, makes positioning easier later.
-            //           If removed the pixmap will be exactly sized, but we'd need a
-            //           vertical offset to render, say "Tg" vs "gg", consistently
-            b.min.y = b.min.y.min(next.min.y).min(0.0);
-            b.max.y = b.max.y.max(next.max.y);
-            b
-        })?;
+        let placements = layout(&primary, &fallbacks, &self.title);
+        let last = placements.last()?;
+        let last_font = font_at(&primary, &fallbacks, last.font_idx);
+        // + 2 because ab_glyph likes to draw outside of its area,
+        // so we add 1px border around the pixmap
+        let width = (last.glyph.position.x + last_font.h_advance(last.glyph.id)).ceil() as u32 + 2;
+        let height = primary.height().ceil() as u32 + 2;
 
-        let width = all_px_bounds.width() as _;
-        let mut pixmap = Pixmap::new(width, all_px_bounds.height() as _)?;
+        let mut pixmap = Pixmap::new(width, height)?;
+
         let pixels = pixmap.pixels_mut();
 
-        for glyph in glyphs {
-            let bounds = glyph.px_bounds();
-            // calc top/left ords in pixmap space
-            // pixmap-x=0 means the *left most pixel*, equivalent to
-            // px_bounds.min.x which *may be non-zero* (and similarly with y)
-            // so `- px_bounds.min` converts the left-most/top-most to 0
-            let pixmap_left = bounds.min.x as u32 - all_px_bounds.min.x as u32;
-            let pixmap_top = bounds.min.y as u32 - all_px_bounds.min.y as u32;
-            glyph.draw(|x, y, c| {
-                // `ab_glyph` may return values greater than 1.0, but they are defined to be
-                // same as 1.0. For our purposes, we need to constrain this value.
-                let c = c.min(1.0);
+        for Placement { font_idx, glyph } in placements {
+            let font = font_at(&primary, &fallbacks, font_idx);
+            if let Some(outline) = font.outline_glyph(glyph) {
+                let bounds = outline.px_bounds();
+                let left = bounds.min.x as u32;
+                let top = bounds.min.y as u32;
+                outline.draw(|x, y, c| {
+                    // `ab_glyph` may return values greater than 1.0, but they are defined to be
+                    // same as 1.0. For our purposes, we need to constrain this value.
+                    let c = c.min(1.0);
 
-                let p_idx = (pixmap_top + y) * width + pixmap_left + x;
-                let Some(pixel) = pixels.get_mut(p_idx as usize) else {
-                    debug_assert!(
-                        false,
-                        "oob pixel: x={x} y={y} top={pixmap_top} left={pixmap_left}, w={width}"
-                    );
-                    return;
-                };
+                    // offset the index by 1, so it is in the center of the pixmap
+                    let p_idx = (top + y + 1) * width + (left + x + 1);
+                    let Some(pixel) = pixels.get_mut(p_idx as usize) else {
+                        // Expected when a fallback glyph (emoji, CJK) draws
+                        // outside the primary font's height bound.
+                        log::debug!("Ignoring out of range pixel (pixel id: {p_idx})");
+                        return;
+                    };
 
-                let old_alpha_u8 = pixel.alpha();
+                    let old_alpha_u8 = pixel.alpha();
 
-                let new_alpha = c + (old_alpha_u8 as f32 / 255.0);
-                if let Some(px) = PremultipliedColorU8::from_rgba(
-                    (self.color.red() * new_alpha * 255.0) as _,
-                    (self.color.green() * new_alpha * 255.0) as _,
-                    (self.color.blue() * new_alpha * 255.0) as _,
-                    (new_alpha * 255.0) as _,
-                ) {
-                    *pixel = px;
-                }
-            })
+                    let new_alpha = c + (old_alpha_u8 as f32 / 255.0);
+                    if let Some(px) = PremultipliedColorU8::from_rgba(
+                        (self.color.red() * new_alpha * 255.0) as _,
+                        (self.color.green() * new_alpha * 255.0) as _,
+                        (self.color.blue() * new_alpha * 255.0) as _,
+                        (new_alpha * 255.0) as _,
+                    ) {
+                        *pixel = px;
+                    }
+                })
+            }
         }
 
         Some(pixmap)
     }
+}
 
-    /// Simple single-line glyph layout starting from `(0, ascent)`.
-    fn layout(&self, font: &PxScaleFont<impl Font>) -> Vec<Glyph> {
-        let mut caret = point(0.0, font.ascent());
-        let mut last_glyph: Option<Glyph> = None;
-        let mut target = Vec::new();
-        for c in self.title.chars() {
-            if c.is_control() {
-                continue;
-            }
-            let mut glyph = font.scaled_glyph(c);
-            if let Some(previous) = last_glyph.take() {
-                caret.x += font.kern(previous.id, glyph.id);
-            }
-            glyph.position = caret;
+/// One positioned glyph plus the index of the font it came from
+/// (`0` = primary, `1..=n` = `fallbacks[idx-1]`).
+struct Placement {
+    font_idx: usize,
+    glyph: Glyph,
+}
 
-            last_glyph = Some(glyph.clone());
-            caret.x += font.h_advance(glyph.id);
+fn font_at<'a, F: Font>(
+    primary: &'a PxScaleFont<F>,
+    fallbacks: &'a [PxScaleFont<F>],
+    idx: usize,
+) -> &'a PxScaleFont<F> {
+    idx.checked_sub(1)
+        .and_then(|i| fallbacks.get(i))
+        .unwrap_or(primary)
+}
 
-            target.push(glyph);
-        }
-        target
+/// Pick the first font (primary, then fallbacks) that has a glyph for `c`.
+/// Returns the font index and the scaled glyph. Falls back to the primary
+/// (`.notdef`) when no font covers `c`.
+fn select<F: Font>(
+    primary: &PxScaleFont<F>,
+    fallbacks: &[PxScaleFont<F>],
+    c: char,
+) -> (usize, Glyph) {
+    let g = primary.scaled_glyph(c);
+    if g.id.0 != 0 {
+        return (0, g);
     }
+    for (i, f) in fallbacks.iter().enumerate() {
+        let g = f.scaled_glyph(c);
+        if g.id.0 != 0 {
+            return (i + 1, g);
+        }
+    }
+    (0, primary.scaled_glyph(c))
+}
+
+fn covers<F: Font>(font: &F, c: char) -> bool {
+    font.glyph_id(c).0 != 0
+}
+
+/// Single-line layout across the primary + fallback fonts. Line metrics come
+/// from the primary; per-glyph advance comes from the covering font. Kerning
+/// is applied only between adjacent glyphs from the same font.
+fn layout<F: Font>(
+    primary: &PxScaleFont<F>,
+    fallbacks: &[PxScaleFont<F>],
+    title: &str,
+) -> Vec<Placement> {
+    let mut caret = point(0.0, primary.ascent());
+    let mut last: Option<(usize, Glyph)> = None;
+    let mut out = Vec::new();
+    for c in title.chars() {
+        if c.is_control() {
+            continue;
+        }
+        let (idx, mut glyph) = select(primary, fallbacks, c);
+        let font = font_at(primary, fallbacks, idx);
+        if let Some((prev_idx, prev_glyph)) = last.take() {
+            if prev_idx == idx {
+                caret.x += font.kern(prev_glyph.id, glyph.id);
+            }
+        }
+        glyph.position = caret;
+        caret.x += font.h_advance(glyph.id);
+        last = Some((idx, glyph.clone()));
+        out.push(Placement { font_idx: idx, glyph });
+    }
+    out
 }
 
 /// Parse the memmapped system font or fallback to built-in cantarell.
@@ -214,4 +273,49 @@ fn font_file_matching(pref: &FontPreference) -> Option<File> {
 fn mmap(file: &File) -> Option<memmap2::Mmap> {
     // Safety: System font files are not expected to be mutated during use
     unsafe { memmap2::Mmap::map(file).ok() }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+
+    fn new_renderer(title: &str) -> AbGlyphTitleText {
+        let mut renderer = AbGlyphTitleText {
+            title: String::new(),
+            font: None, // forces fallback to bundled Cantarell
+            fallbacks: FallbackCache::default(),
+            original_px_size: 17.6,
+            size: PxScale { x: 17.6, y: 17.6 },
+            color: Color::BLACK,
+            pixmap: None,
+        };
+        renderer.update_title(title);
+        renderer
+    }
+
+    /// Regression: '★' is not in Cantarell. Before this fix it silently
+    /// rendered as Cantarell's `.notdef` glyph. The fix must load a fallback
+    /// face that has it. Verified separately on pre-fix code (rendering a
+    /// missing codepoint and a different missing codepoint produced
+    /// byte-identical pixmaps — both `.notdef`).
+    #[test]
+    fn loads_fallback_for_missing_codepoint() {
+        let renderer = new_renderer("★");
+        assert!(
+            !renderer.fallbacks.fonts.is_empty(),
+            "'★' is not in Cantarell — a fallback face must have been loaded"
+        );
+    }
+
+    /// Pure-ASCII titles must not trigger any fallback lookups.
+    #[test]
+    fn no_fallback_for_ascii_title() {
+        let renderer = new_renderer("hello");
+        assert!(
+            renderer.fallbacks.fonts.is_empty(),
+            "ASCII fits in Cantarell, no fallback should be loaded"
+        );
+    }
 }

--- a/src/title/font_fallback.rs
+++ b/src/title/font_fallback.rs
@@ -1,0 +1,116 @@
+//! Per-codepoint font fallback discovery via `fc-match`.
+//!
+//! The `ab_glyph` and `skrifa` title renderers each load a single primary font.
+//! When the title contains a codepoint not covered by that font (emoji, CJK,
+//! many symbol ranges), this module finds an additional face that does cover it
+//! using `fc-match -f '%{file}' :charset=HEX`, memory-maps it, and hands it back
+//! for the backend to parse. Results are cached per-renderer; missing-coverage
+//! lookups happen at most once per unique codepoint.
+
+use std::{collections::HashSet, fs::File, process::Command};
+
+/// Cache of fallback face mmaps and per-codepoint discovery state.
+///
+/// `fonts` is the ordered list of fallback faces; backends parse these into
+/// their own font handles each render. Discovery is one-shot per codepoint
+/// (`seen_chars`) and faces are deduped by file path (`paths`).
+#[derive(Debug, Default)]
+pub(crate) struct FallbackCache {
+    pub fonts: Vec<memmap2::Mmap>,
+    paths: HashSet<String>,
+    seen_chars: HashSet<char>,
+}
+
+impl FallbackCache {
+    /// For each char in `text` not already considered, call `covered` to ask
+    /// whether the caller already has coverage. If not, run `fc-match` and
+    /// push a deduped fallback face. The closure may inspect `&self.fonts`
+    /// (already loaded so far) to know which faces are currently available;
+    /// each char is checked against fallbacks pushed by earlier chars in the
+    /// same call, so a single font can satisfy multiple codepoints.
+    pub fn extend<F>(&mut self, text: &str, mut covered: F)
+    where
+        F: FnMut(char, &[memmap2::Mmap]) -> bool,
+    {
+        for c in text.chars() {
+            if c.is_control() {
+                continue;
+            }
+            if !self.seen_chars.insert(c) {
+                continue;
+            }
+            if covered(c, &self.fonts) {
+                continue;
+            }
+            let Some((path, mmap)) = find_font_for_char(c) else {
+                continue;
+            };
+            if !self.paths.insert(path) {
+                continue;
+            }
+            self.fonts.push(mmap);
+        }
+    }
+}
+
+/// `fc-match :charset=HEX` for the smallest font with `c` in its charset.
+fn find_font_for_char(c: char) -> Option<(String, memmap2::Mmap)> {
+    let pattern = format!(":charset={:X}", c as u32);
+    let out = Command::new("fc-match")
+        .arg("-f")
+        .arg("%{file}")
+        .arg(&pattern)
+        .output()
+        .ok()?;
+    let path = String::from_utf8(out.stdout).ok()?.trim().to_owned();
+    if path.is_empty() {
+        return None;
+    }
+    let file = File::open(&path).ok()?;
+    // Safety: System font files are not expected to be mutated during use.
+    let mmap = unsafe { memmap2::Mmap::map(&file).ok()? };
+    Some((path, mmap))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+
+    #[test]
+    fn extend_dedupes_paths() {
+        let mut cache = FallbackCache::default();
+        // Force two ASCII chars to "miss" so fc-match is consulted for each.
+        // Distinct ASCII letters resolve to the same default sans font on any
+        // reasonable system, so the deduped fallback list should be ≤ 1.
+        cache.extend("ab", |_, _| false);
+        assert!(
+            cache.fonts.len() <= 1,
+            "two ASCII chars must share at most one fallback face, got {}",
+            cache.fonts.len()
+        );
+    }
+
+    #[test]
+    fn extend_skips_already_seen_chars() {
+        let mut cache = FallbackCache::default();
+        let mut calls = 0;
+        cache.extend("aa", |_, _| {
+            calls += 1;
+            true
+        });
+        assert_eq!(calls, 1, "the second 'a' should not invoke the closure");
+    }
+
+    #[test]
+    fn extend_skips_control_chars() {
+        let mut cache = FallbackCache::default();
+        let mut calls = 0;
+        cache.extend("\n\t\r", |_, _| {
+            calls += 1;
+            true
+        });
+        assert_eq!(calls, 0, "control chars should be skipped entirely");
+    }
+}

--- a/src/title/skrifa_renderer.rs
+++ b/src/title/skrifa_renderer.rs
@@ -4,11 +4,14 @@
 //!
 //! Can fallback to an embedded Cantarell-Regular.ttf font (SIL Open Font Licence v1.1)
 //! if the system font doesn't work.
-use crate::title::{config, font_preference::FontPreference};
+//!
+//! Per-codepoint fallback faces (emoji, CJK, …) are discovered via `fc-match`;
+//! see [`crate::title::font_fallback`].
+use crate::title::{config, font_fallback::FallbackCache, font_preference::FontPreference};
 use skrifa::{
     instance::{LocationRef, Size},
     outline::{DrawSettings, HintingInstance, HintingOptions, OutlinePen},
-    MetadataProvider,
+    GlyphId, MetadataProvider,
 };
 use std::{fs::File, process::Command};
 use tiny_skia::{Color, FillRule, Paint, Pixmap, Transform};
@@ -19,6 +22,7 @@ const CANTARELL: &[u8] = include_bytes!("Cantarell-Regular.ttf");
 pub struct SkrifaTitleText {
     title: String,
     font: Option<(memmap2::Mmap, FontPreference)>,
+    fallbacks: FallbackCache,
     original_px_size: f32,
     px_size: f32,
     color: Color,
@@ -38,6 +42,7 @@ impl SkrifaTitleText {
         Self {
             title: <_>::default(),
             font,
+            fallbacks: FallbackCache::default(),
             original_px_size: px_size,
             px_size,
             color,
@@ -57,6 +62,7 @@ impl SkrifaTitleText {
         let new_title = title.into();
         if new_title != self.title {
             self.title = new_title;
+            self.discover_fallbacks();
             self.pixmap = self.render();
         }
     }
@@ -72,50 +78,62 @@ impl SkrifaTitleText {
         self.pixmap.as_ref()
     }
 
+    /// Load additional faces for any title codepoint not covered by the primary
+    /// font or any previously-loaded fallback.
+    fn discover_fallbacks(&mut self) {
+        let primary = parse_font(&self.font);
+        self.fallbacks.extend(&self.title, |c, loaded| {
+            covers(&primary, c)
+                || loaded
+                    .iter()
+                    .any(|m| skrifa::FontRef::from_index(m, 0).is_ok_and(|fr| covers(&fr, c)))
+        });
+    }
+
     /// Render returning the new `Pixmap`.
     fn render(&self) -> Option<Pixmap> {
         if self.title.is_empty() {
             return None;
         }
 
-        let font = parse_font(&self.font);
+        let primary = parse_font(&self.font);
+        let fallbacks: Vec<_> = self
+            .fallbacks
+            .fonts
+            .iter()
+            .filter_map(|m| skrifa::FontRef::from_index(m, 0).ok())
+            .collect();
+
         let size = Size::new(self.px_size);
         let location = LocationRef::default();
+        let metrics = primary.metrics(size, location);
 
-        let metrics = font.metrics(size, location);
-        let glyph_metrics = font.glyph_metrics(size, location);
-        let charmap = font.charmap();
-        let outlines = font.outline_glyphs();
+        // Per-font caches: metrics, charmap, outlines, hinting. Hinting falls
+        // back to unhinted rendering if the font doesn't support it.
+        let primary_face = Face::new(&primary, size, location);
+        let fallback_faces: Vec<Face<'_>> = fallbacks
+            .iter()
+            .map(|f| Face::new(f, size, location))
+            .collect();
 
-        // Create a hinting instance for better glyph quality at small sizes.
-        // Falls back to unhinted rendering if the font doesn't support hinting.
-        let hinting =
-            HintingInstance::new(&outlines, size, location, HintingOptions::default()).ok();
-
-        // Layout glyphs and collect paths
+        // Layout: pick the first face (primary, then fallbacks) that covers each char.
         let mut paths: Vec<(tiny_skia::Path, f32, f32)> = Vec::new();
         let mut caret: f32 = 0.0;
         let ascent = metrics.ascent;
 
-        let mut last_glyph_id = None;
         for c in self.title.chars() {
             if c.is_control() {
                 continue;
             }
 
-            let glyph_id = charmap.map(c).unwrap_or_default();
-
-            // Kerning (if available)
-            // Note: skrifa doesn't expose a simple kern method on glyph_metrics,
-            // so we skip kerning for simplicity. The visual difference is minimal
-            // for title bar text.
-            let _ = last_glyph_id;
+            let face = select_face(&primary_face, &fallback_faces, c);
+            let glyph_id = face.charmap_get(c).unwrap_or_default();
 
             let mut pb = tiny_skia::PathBuilder::new();
             let mut pen = PathPen(&mut pb);
 
-            if let Some(outline) = outlines.get(glyph_id) {
-                let settings = match &hinting {
+            if let Some(outline) = face.outlines.get(glyph_id) {
+                let settings = match &face.hinting {
                     Some(h) => DrawSettings::from(h),
                     None => DrawSettings::unhinted(size, location),
                 };
@@ -126,8 +144,7 @@ impl SkrifaTitleText {
                 paths.push((path, caret, ascent));
             }
 
-            caret += glyph_metrics.advance_width(glyph_id).unwrap_or(0.0);
-            last_glyph_id = Some(glyph_id);
+            caret += face.glyph_metrics.advance_width(glyph_id).unwrap_or(0.0);
         }
 
         if paths.is_empty() {
@@ -155,6 +172,61 @@ impl SkrifaTitleText {
 
         Some(pixmap)
     }
+}
+
+/// One parsed face + per-size caches reused across the line.
+struct Face<'a> {
+    charmap: skrifa::charmap::Charmap<'a>,
+    outlines: skrifa::outline::OutlineGlyphCollection<'a>,
+    glyph_metrics: skrifa::metrics::GlyphMetrics<'a>,
+    hinting: Option<HintingInstance>,
+}
+
+impl<'a> Face<'a> {
+    fn new(font: &skrifa::FontRef<'a>, size: Size, location: LocationRef<'a>) -> Self {
+        let outlines = font.outline_glyphs();
+        let hinting =
+            HintingInstance::new(&outlines, size, location, HintingOptions::default()).ok();
+        Self {
+            charmap: font.charmap(),
+            glyph_metrics: font.glyph_metrics(size, location),
+            outlines,
+            hinting,
+        }
+    }
+
+    fn charmap_get(&self, c: char) -> Option<GlyphId> {
+        let id = self.charmap.map(c)?;
+        // Treat `.notdef` (id 0) as no coverage so we look further down the stack.
+        if id == GlyphId::NOTDEF {
+            None
+        } else {
+            Some(id)
+        }
+    }
+}
+
+fn covers(font: &skrifa::FontRef<'_>, c: char) -> bool {
+    match font.charmap().map(c) {
+        Some(id) => id != GlyphId::NOTDEF,
+        None => false,
+    }
+}
+
+/// Pick the first face that covers `c`, falling back to the primary face
+/// (which will draw `.notdef`) when no face has it.
+fn select_face<'a, 'b>(
+    primary: &'a Face<'b>,
+    fallbacks: &'a [Face<'b>],
+    c: char,
+) -> &'a Face<'b> {
+    if primary.charmap_get(c).is_some() {
+        return primary;
+    }
+    fallbacks
+        .iter()
+        .find(|f| f.charmap_get(c).is_some())
+        .unwrap_or(primary)
 }
 
 /// Convert point size to pixel size using font's units_per_em.
@@ -241,6 +313,7 @@ mod tests {
         let mut renderer = SkrifaTitleText {
             title: String::new(),
             font: None, // forces fallback to bundled Cantarell
+            fallbacks: FallbackCache::default(),
             original_px_size: 13.3,
             px_size: 13.3,
             color: Color::BLACK,
@@ -301,5 +374,28 @@ mod tests {
         let metrics = font.metrics(Size::new(16.0), LocationRef::default());
         assert!(metrics.units_per_em > 0);
         assert!(metrics.ascent > 0.0);
+    }
+
+    /// Regression: '★' is not in Cantarell. Before this fix it silently
+    /// rendered as Cantarell's `.notdef` glyph. The fix must load a fallback
+    /// face that has it.
+    #[test]
+    fn loads_fallback_for_missing_codepoint() {
+        let mut renderer = new_renderer();
+        renderer.update_title("★");
+        assert!(
+            !renderer.fallbacks.fonts.is_empty(),
+            "'★' is not in Cantarell — a fallback face must have been loaded"
+        );
+    }
+
+    /// Pure-ASCII titles must not trigger any fallback lookups.
+    #[test]
+    fn no_fallback_for_ascii_title() {
+        let renderer = new_renderer();
+        assert!(
+            renderer.fallbacks.fonts.is_empty(),
+            "ASCII fits in Cantarell, no fallback should be loaded"
+        );
     }
 }


### PR DESCRIPTION
Fixes #96.

## Problem

Both the `ab_glyph` and the new `skrifa` title renderers load a single primary font (whatever `fc-match` returns for the GNOME `titlebar-font` preference, defaulting to Cantarell) and lay out every codepoint with that one font. Any codepoint not in the primary's charset — emoji, CJK, most symbol ranges — silently becomes `.notdef`, so its advance is consumed but no real glyph is drawn.

Most visible on GNOME/Mutter Wayland, which forces CSD on clients, so every titlebar Rio / Alacritty / winit-based app paints is affected. A title like `hello 😀 你好 ★` renders with three identical hollow boxes.

Reproduction (verified empirically): on the pre-fix code, `'★'` (U+2605) and `'█'` (U+2588) — both absent from Cantarell — produce **byte-identical** pixmaps, because both are drawn as the same `.notdef` glyph.

## Fix

New `src/title/font_fallback.rs`: for each title char not covered by the primary or any already-loaded face, run `fc-match -f '%{file}' :charset=HEX`, mmap the file once, and cache it (deduped by path; seen chars not re-queried). Discovery happens in `update_title`, not in render.

Both backends now parse the primary + fallback faces each render and pick the first face that has a glyph for each char (`select` / `select_face`). Layout rules:

- Line metrics come from the primary, so fallback faces with wild ascent/descent don't grow the title bar.
- Per-glyph advance comes from the covering face.
- Kerning is only applied between adjacent glyphs that came from the same face.

`crossfont` has the same single-face limitation but a different code shape (it owns the rasterizer); leaving it as a follow-up.

The previously-`warn!`-level "Ignoring out of range pixel" log in the `ab_glyph` renderer is now `debug!` — it fires on the fallback path whenever a fallback glyph's outline extends past the primary's height bound, which is expected.

## Tests

Two regression tests per backend (in `ab_glyph_renderer.rs` and `skrifa_renderer.rs`):

- `loads_fallback_for_missing_codepoint` — bypasses the system font, sets title `'★'`, asserts a fallback face was loaded. This is the structural invariant; the bug was that `fallbacks` would always be empty.
- `no_fallback_for_ascii_title` — sets title `"hello"`, asserts no fallback lookups happened.

Verified on the pre-fix code (separately) that two distinct missing codepoints produce byte-identical `.notdef` pixmaps — the smoking gun. The committed tests use the structural assertion rather than a pixmap comparison because the latter depends on font specifics (a `.notdef` that renders the hex codepoint inside the box would mask the bug).

All four feature configurations build clean (`ab_glyph`, `skrifa`, `crossfont`, default) and tests pass on the touched backends:

```
ab_glyph: 32 passed
skrifa:   38 passed
```

(Pre-existing clippy lints in `crossfont_renderer.rs` and a few `mismatched_lifetime_syntaxes` warnings in `parts.rs` / `theme.rs` are unrelated and untouched here.)

## Downstream

Downstream user-visible report: https://github.com/raphamorim/rio/issues/1622