### PR TITLE
Add cosmic-text title renderer (shaping + font fallback)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,3 +99,25 @@ jobs:
         with:
           command: build
           args: --no-default-features --features ab_glyph
+
+  cosmic-text-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --no-default-features --features cosmic-text
+
+      - name: Run cargo clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --no-default-features --features cosmic-text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
         ```toml
         sctk-adwaita = { default-features = false, features = ["skrifa"] }
         ```
+- `cosmic-text` feature got added (for `cosmic-text` based title rendering with shaping and font fallback)
+    - Can be enabled like this:
+        ```toml
+        sctk-adwaita = { default-features = false, features = ["cosmic-text"] }
+        ```
 
 ## 0.11.0
 - Improve `ab_glyph` rendering to properly account for glyph outlines that would have previously been out of bounds

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ ab_glyph = { version = "0.2.17", optional = true }
 # Draw title text using skrifa + tiny-skia `--features skrifa`
 skrifa = { version = "0.40", optional = true }
 # Draw title text using cosmic-text `--features cosmic-text`
-cosmic-text = { version = "0.10.0", optional = true }
+cosmic-text = { version = "0.19.0", optional = true }
 
 [dev-dependencies]
 tiny-skia = { version = "0.12", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tiny-skia = { version = "0.12", default-features = false, features = [
   "simd",
 ] }
 smithay-client-toolkit = { version = "0.20.0", default-features = false }
+once_cell = { version = "1.16.0", optional = true }
 
 # Draw title text using crossfont `--features crossfont`
 crossfont = { version = "0.9.0", optional = true }
@@ -28,6 +29,8 @@ crossfont = { version = "0.9.0", optional = true }
 ab_glyph = { version = "0.2.17", optional = true }
 # Draw title text using skrifa + tiny-skia `--features skrifa`
 skrifa = { version = "0.40", optional = true }
+# Draw title text using cosmic-text `--features cosmic-text`
+cosmic-text = { version = "0.10.0", optional = true }
 
 [dev-dependencies]
 tiny-skia = { version = "0.12", default-features = false, features = [
@@ -41,3 +44,4 @@ default = ["ab_glyph"]
 crossfont = ["dep:crossfont"]
 ab_glyph = ["dep:ab_glyph", "memmap2"]
 skrifa = ["dep:skrifa", "memmap2"]
+cosmic-text = ["once_cell", "dep:cosmic-text"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ tiny-skia = { version = "0.12", default-features = false, features = [
   "simd",
 ] }
 smithay-client-toolkit = { version = "0.20.0", default-features = false }
-once_cell = { version = "1.16.0", optional = true }
 
 # Draw title text using crossfont `--features crossfont`
 crossfont = { version = "0.9.0", optional = true }
@@ -44,4 +43,4 @@ default = ["ab_glyph"]
 crossfont = ["dep:crossfont"]
 ab_glyph = ["dep:ab_glyph", "memmap2"]
 skrifa = ["dep:skrifa", "memmap2"]
-cosmic-text = ["once_cell", "dep:cosmic-text"]
+cosmic-text = ["dep:cosmic-text"]

--- a/src/title.rs
+++ b/src/title.rs
@@ -1,18 +1,36 @@
 use tiny_skia::{Color, Pixmap};
 
-#[cfg(any(feature = "crossfont", feature = "skrifa", feature = "ab_glyph"))]
+#[cfg(any(
+    feature = "crossfont",
+    feature = "cosmic-text",
+    feature = "skrifa",
+    feature = "ab_glyph"
+))]
 mod config;
-#[cfg(any(feature = "crossfont", feature = "skrifa", feature = "ab_glyph"))]
+#[cfg(any(
+    feature = "crossfont",
+    feature = "cosmic-text",
+    feature = "skrifa",
+    feature = "ab_glyph"
+))]
 mod font_preference;
 
 #[cfg(feature = "crossfont")]
 mod crossfont_renderer;
 
-#[cfg(all(not(feature = "crossfont"), feature = "skrifa"))]
+#[cfg(all(not(feature = "crossfont"), feature = "cosmic-text"))]
+mod cosmic_text_renderer;
+
+#[cfg(all(
+    not(feature = "crossfont"),
+    not(feature = "cosmic-text"),
+    feature = "skrifa"
+))]
 mod skrifa_renderer;
 
 #[cfg(all(
     not(feature = "crossfont"),
+    not(feature = "cosmic-text"),
     not(feature = "skrifa"),
     feature = "ab_glyph"
 ))]
@@ -20,6 +38,7 @@ mod ab_glyph_renderer;
 
 #[cfg(all(
     not(feature = "crossfont"),
+    not(feature = "cosmic-text"),
     not(feature = "skrifa"),
     not(feature = "ab_glyph")
 ))]
@@ -29,16 +48,24 @@ mod dumb;
 pub struct TitleText {
     #[cfg(feature = "crossfont")]
     imp: crossfont_renderer::CrossfontTitleText,
-    #[cfg(all(not(feature = "crossfont"), feature = "skrifa"))]
+    #[cfg(all(not(feature = "crossfont"), feature = "cosmic-text"))]
+    imp: cosmic_text_renderer::CosmicTextTitleText,
+    #[cfg(all(
+        not(feature = "crossfont"),
+        not(feature = "cosmic-text"),
+        feature = "skrifa"
+    ))]
     imp: skrifa_renderer::SkrifaTitleText,
     #[cfg(all(
         not(feature = "crossfont"),
+        not(feature = "cosmic-text"),
         not(feature = "skrifa"),
         feature = "ab_glyph"
     ))]
     imp: ab_glyph_renderer::AbGlyphTitleText,
     #[cfg(all(
         not(feature = "crossfont"),
+        not(feature = "cosmic-text"),
         not(feature = "skrifa"),
         not(feature = "ab_glyph")
     ))]
@@ -52,13 +79,23 @@ impl TitleText {
             .ok()
             .map(|imp| Self { imp });
 
-        #[cfg(all(not(feature = "crossfont"), feature = "skrifa"))]
+        #[cfg(all(not(feature = "crossfont"), feature = "cosmic-text"))]
+        return Some(Self {
+            imp: cosmic_text_renderer::CosmicTextTitleText::new(color),
+        });
+
+        #[cfg(all(
+            not(feature = "crossfont"),
+            not(feature = "cosmic-text"),
+            feature = "skrifa"
+        ))]
         return Some(Self {
             imp: skrifa_renderer::SkrifaTitleText::new(color),
         });
 
         #[cfg(all(
             not(feature = "crossfont"),
+            not(feature = "cosmic-text"),
             not(feature = "skrifa"),
             feature = "ab_glyph"
         ))]
@@ -68,6 +105,7 @@ impl TitleText {
 
         #[cfg(all(
             not(feature = "crossfont"),
+            not(feature = "cosmic-text"),
             not(feature = "skrifa"),
             not(feature = "ab_glyph")
         ))]

--- a/src/title/cosmic_text_renderer.rs
+++ b/src/title/cosmic_text_renderer.rs
@@ -1,0 +1,141 @@
+use crate::title::{config, font_preference::FontPreference};
+use cosmic_text::{
+    Attrs, AttrsList, BufferLine, Color as CosmicColor, Family, FontSystem, Metrics, Shaping,
+    SwashCache, Wrap,
+};
+use tiny_skia::{Color, ColorU8, Pixmap, PremultipliedColorU8};
+
+// Use arbitrarily large width, then calculate max/min x from resulting glyphs
+const MAX_WIDTH: f32 = 1024.0 * 1024.0;
+
+fn attrs_from_font_pref(font_preference: &FontPreference) -> Attrs {
+    let attrs = Attrs::new().family(Family::Name(&font_preference.name));
+    if let Some(style) = &font_preference.style {
+        // TODO
+    }
+    attrs
+}
+
+pub struct CosmicTextTitleText {
+    buffer_line: BufferLine,
+    cache: SwashCache,
+    color: Color,
+    scale: u32,
+    pixmap: Option<Pixmap>,
+    font_pref: FontPreference,
+    font_system: FontSystem,
+}
+
+impl std::fmt::Debug for CosmicTextTitleText {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TitleText")
+            .field("color", &self.color)
+            .field("scale", &self.scale)
+            .field("pixmap", &self.pixmap)
+            .field("font_pref", &self.font_pref)
+            .finish()
+    }
+}
+
+impl CosmicTextTitleText {
+    pub fn new(color: Color) -> Self {
+        let buffer_line = BufferLine::new("", AttrsList::new(Attrs::new()), Shaping::Advanced);
+        let cache = SwashCache::new();
+        let font_pref = config::titlebar_font().unwrap_or_default();
+        Self {
+            buffer_line,
+            cache,
+            color,
+            scale: 1,
+            pixmap: None,
+            font_pref,
+            font_system: FontSystem::new(),
+        }
+    }
+
+    pub fn update_scale(&mut self, scale: u32) {
+        self.scale = scale;
+        self.update_pixmap();
+    }
+
+    pub fn update_title<S: Into<String>>(&mut self, title: S) {
+        let attrs = attrs_from_font_pref(&self.font_pref);
+        self.buffer_line
+            .set_text(title.into(), AttrsList::new(attrs));
+        self.update_pixmap();
+    }
+
+    pub fn update_color(&mut self, color: Color) {
+        self.color = color;
+        self.update_pixmap();
+    }
+
+    pub fn pixmap(&self) -> Option<&Pixmap> {
+        self.pixmap.as_ref()
+    }
+
+    fn update_pixmap(&mut self) {
+        self.pixmap = None;
+
+        let shape_line = self.buffer_line.shape(&mut self.font_system);
+
+        let height = (1.4 * self.scale as f32 * self.font_pref.pt_size * 96.0 / 72.0).ceil() as i32; // ?
+        let layout_lines = shape_line.layout(height as f32, MAX_WIDTH, Wrap::Word, None);
+        let layout_line = &layout_lines[0];
+        let min_x = layout_line
+            .glyphs
+            .iter()
+            .map(|i| i.x.floor() as u32)
+            .min()
+            .unwrap_or(0);
+        let width = layout_line.w.ceil() as u32;
+
+        let mut pixmap = match Pixmap::new(width, height as u32) {
+            Some(pixmap) => pixmap,
+            None => return,
+        };
+        let pixels = pixmap.pixels_mut();
+
+        let color = self.color.to_color_u8();
+        let color = CosmicColor::rgba(color.red(), color.green(), color.blue(), color.alpha());
+        for glyph in &layout_line.glyphs {
+            let physical_glyph = glyph.physical((0., 0.), 1.); // TODO scale
+            self.cache.with_pixels(
+                &mut self.font_system,
+                physical_glyph.cache_key,
+                color,
+                |pixel_x, pixel_y, color| {
+                    if color.a() == 0 {
+                        return;
+                    }
+
+                    let y = height + physical_glyph.y + pixel_y;
+                    let x = physical_glyph.x + pixel_x - min_x as i32;
+                    let idx = y * width as i32 + x;
+                    if idx >= 0 && (idx as usize) < pixels.len() {
+                        let idx = idx as usize;
+                        let color = ColorU8::from_rgba(color.r(), color.g(), color.b(), color.a());
+                        pixels[idx] = alpha_blend(color.premultiply(), pixels[idx]);
+                    }
+                },
+            );
+        }
+
+        self.pixmap = Some(pixmap);
+    }
+}
+
+// `a` over `b`
+// This should be correct but not especially efficient.
+fn alpha_blend(a: PremultipliedColorU8, b: PremultipliedColorU8) -> PremultipliedColorU8 {
+    let blend_channel = |channel_a: u8, channel_b: u8| -> u8 {
+        channel_a.saturating_add(channel_b.saturating_mul(255 - a.alpha()))
+    };
+    PremultipliedColorU8::from_rgba(
+        blend_channel(a.red(), b.red()),
+        blend_channel(a.green(), b.green()),
+        blend_channel(a.blue(), b.blue()),
+        blend_channel(a.alpha(), b.alpha()),
+    )
+    .unwrap()
+}

--- a/src/title/cosmic_text_renderer.rs
+++ b/src/title/cosmic_text_renderer.rs
@@ -1,17 +1,28 @@
 use crate::title::{config, font_preference::FontPreference};
 use cosmic_text::{
-    Attrs, AttrsList, BufferLine, Color as CosmicColor, Family, FontSystem, Metrics, Shaping,
-    SwashCache, Wrap,
+    Attrs, AttrsList, BufferLine, Color as CosmicColor, Family, FontSystem, Shaping, Style,
+    SwashCache, Weight, Wrap,
 };
 use tiny_skia::{Color, ColorU8, Pixmap, PremultipliedColorU8};
 
 // Use arbitrarily large width, then calculate max/min x from resulting glyphs
 const MAX_WIDTH: f32 = 1024.0 * 1024.0;
 
-fn attrs_from_font_pref(font_preference: &FontPreference) -> Attrs {
-    let attrs = Attrs::new().family(Family::Name(&font_preference.name));
+fn attrs_from_font_pref(font_preference: &FontPreference) -> Attrs<'_> {
+    let mut attrs = Attrs::new().family(Family::Name(&font_preference.name));
+    // The GNOME `titlebar-font` style is a free-form descriptor such as
+    // "Bold", "Italic", or "Bold Italic"; map the keywords we understand onto
+    // cosmic-text weight/style and ignore the rest.
     if let Some(style) = &font_preference.style {
-        // TODO
+        let style = style.to_ascii_lowercase();
+        if style.contains("bold") {
+            attrs = attrs.weight(Weight::BOLD);
+        }
+        if style.contains("italic") {
+            attrs = attrs.style(Style::Italic);
+        } else if style.contains("oblique") {
+            attrs = attrs.style(Style::Oblique);
+        }
     }
     attrs
 }
@@ -79,20 +90,30 @@ impl CosmicTextTitleText {
 
         let shape_line = self.buffer_line.shape(&mut self.font_system);
 
-        let height = (1.4 * self.scale as f32 * self.font_pref.pt_size * 96.0 / 72.0).ceil() as i32; // ?
-        let layout_lines = shape_line.layout(height as f32, MAX_WIDTH, Wrap::Word, None);
-        let layout_line = &layout_lines[0];
+        // Font size in device pixels: points -> pixels at 96 DPI, scaled by
+        // the integer output scale. This is the em size handed to `layout()`,
+        // NOT the line box height.
+        let font_size = self.scale as f32 * self.font_pref.pt_size * 96.0 / 72.0;
+        let layout_lines = shape_line.layout(font_size, MAX_WIDTH, Wrap::Word, None);
+        let Some(layout_line) = layout_lines.first() else {
+            return;
+        };
         let min_x = layout_line
             .glyphs
             .iter()
-            .map(|i| i.x.floor() as u32)
+            .map(|i| i.x.floor() as i32)
             .min()
             .unwrap_or(0);
         let width = layout_line.w.ceil() as u32;
 
-        let mut pixmap = match Pixmap::new(width, height as u32) {
-            Some(pixmap) => pixmap,
-            None => return,
+        // Size the pixmap from the run's actual ascent + descent and place the
+        // baseline at `max_ascent`. Using the font size as the height (with the
+        // baseline pinned to the bottom) clips descenders.
+        let baseline = layout_line.max_ascent.ceil() as i32;
+        let height = (layout_line.max_ascent + layout_line.max_descent).ceil() as u32;
+
+        let Some(mut pixmap) = Pixmap::new(width, height) else {
+            return;
         };
         let pixels = pixmap.pixels_mut();
 
@@ -109,8 +130,11 @@ impl CosmicTextTitleText {
                         return;
                     }
 
-                    let y = height + physical_glyph.y + pixel_y;
-                    let x = physical_glyph.x + pixel_x - min_x as i32;
+                    let y = baseline + physical_glyph.y + pixel_y;
+                    let x = physical_glyph.x + pixel_x - min_x;
+                    if x < 0 || x >= width as i32 {
+                        return;
+                    }
                     let idx = y * width as i32 + x;
                     if idx >= 0 && (idx as usize) < pixels.len() {
                         let idx = idx as usize;

--- a/src/title/cosmic_text_renderer.rs
+++ b/src/title/cosmic_text_renderer.rs
@@ -151,10 +151,12 @@ impl CosmicTextTitleText {
                         return;
                     }
                     let idx = y * width as i32 + x;
-                    if idx >= 0 && (idx as usize) < pixels.len() {
-                        let idx = idx as usize;
+                    if idx < 0 {
+                        return;
+                    }
+                    if let Some(pixel) = pixels.get_mut(idx as usize) {
                         let color = ColorU8::from_rgba(color.r(), color.g(), color.b(), color.a());
-                        pixels[idx] = alpha_blend(color.premultiply(), pixels[idx]);
+                        *pixel = alpha_blend(color.premultiply(), *pixel);
                     }
                 },
             );
@@ -167,14 +169,18 @@ impl CosmicTextTitleText {
 // `a` over `b`
 // This should be correct but not especially efficient.
 fn alpha_blend(a: PremultipliedColorU8, b: PremultipliedColorU8) -> PremultipliedColorU8 {
+    let inv_alpha = 255 - u16::from(a.alpha());
     let blend_channel = |channel_a: u8, channel_b: u8| -> u8 {
-        channel_a.saturating_add(channel_b.saturating_mul(255 - a.alpha()))
+        let blended = u16::from(channel_a) + u16::from(channel_b) * inv_alpha / 255;
+        blended.min(255) as u8
     };
+    // Channels stay <= alpha through the blend, so this can't actually be
+    // `None`; fall back to the destination pixel rather than panicking.
     PremultipliedColorU8::from_rgba(
         blend_channel(a.red(), b.red()),
         blend_channel(a.green(), b.green()),
         blend_channel(a.blue(), b.blue()),
         blend_channel(a.alpha(), b.alpha()),
     )
-    .unwrap()
+    .unwrap_or(b)
 }

--- a/src/title/cosmic_text_renderer.rs
+++ b/src/title/cosmic_text_renderer.rs
@@ -1,12 +1,15 @@
 use crate::title::{config, font_preference::FontPreference};
 use cosmic_text::{
-    Attrs, AttrsList, BufferLine, Color as CosmicColor, Family, FontSystem, Shaping, Style,
-    SwashCache, Weight, Wrap,
+    Attrs, AttrsList, BufferLine, Color as CosmicColor, Family, FontSystem, Hinting, LineEnding,
+    Shaping, Style, SwashCache, Weight, Wrap,
 };
 use tiny_skia::{Color, ColorU8, Pixmap, PremultipliedColorU8};
 
 // Use arbitrarily large width, then calculate max/min x from resulting glyphs
 const MAX_WIDTH: f32 = 1024.0 * 1024.0;
+
+// Title text never contains tabs; this is just the value `shape()` requires.
+const TAB_WIDTH: u16 = 8;
 
 fn attrs_from_font_pref(font_preference: &FontPreference) -> Attrs<'_> {
     let mut attrs = Attrs::new().family(Family::Name(&font_preference.name));
@@ -50,7 +53,12 @@ impl std::fmt::Debug for CosmicTextTitleText {
 
 impl CosmicTextTitleText {
     pub fn new(color: Color) -> Self {
-        let buffer_line = BufferLine::new("", AttrsList::new(Attrs::new()), Shaping::Advanced);
+        let buffer_line = BufferLine::new(
+            "",
+            LineEnding::default(),
+            AttrsList::new(&Attrs::new()),
+            Shaping::Advanced,
+        );
         let cache = SwashCache::new();
         let font_pref = config::titlebar_font().unwrap_or_default();
         Self {
@@ -72,7 +80,7 @@ impl CosmicTextTitleText {
     pub fn update_title<S: Into<String>>(&mut self, title: S) {
         let attrs = attrs_from_font_pref(&self.font_pref);
         self.buffer_line
-            .set_text(title.into(), AttrsList::new(attrs));
+            .set_text(title.into(), LineEnding::default(), AttrsList::new(&attrs));
         self.update_pixmap();
     }
 
@@ -88,13 +96,20 @@ impl CosmicTextTitleText {
     fn update_pixmap(&mut self) {
         self.pixmap = None;
 
-        let shape_line = self.buffer_line.shape(&mut self.font_system);
+        let shape_line = self.buffer_line.shape(&mut self.font_system, TAB_WIDTH);
 
         // Font size in device pixels: points -> pixels at 96 DPI, scaled by
         // the integer output scale. This is the em size handed to `layout()`,
         // NOT the line box height.
         let font_size = self.scale as f32 * self.font_pref.pt_size * 96.0 / 72.0;
-        let layout_lines = shape_line.layout(font_size, MAX_WIDTH, Wrap::Word, None);
+        let layout_lines = shape_line.layout(
+            font_size,
+            Some(MAX_WIDTH),
+            Wrap::Word,
+            None,
+            None,
+            Hinting::Disabled,
+        );
         let Some(layout_line) = layout_lines.first() else {
             return;
         };


### PR DESCRIPTION
## Summary

Adds **cosmic-text** as a title-text renderer for the CSD frame, as an alternative to the existing `ab_glyph` / `skrifa` / `crossfont` backends.

This revives and finishes @ids1024's #16: it rebases the renderer onto current `master` (slotting it into the renderer-selection chain next to `skrifa`), and fixes the sizing bugs that made the original "not quite working".

Motivation is #96: the single-font `ab_glyph`/`skrifa` renderers have no fallback chain, so any codepoint missing from the primary font (emoji, CJK, many symbol ranges) renders as a `.notdef` hollow box. cosmic-text shapes text properly (bidi/RTL included) and walks a real fallback chain via `fontdb`, so missing codepoints resolve to a covering face. Since the title bar draws text in a single theme colour, monochrome fallback is all that's needed.

## What changed vs #16

- Rebased onto `master`; renderer selection is ordered `crossfont > cosmic-text > skrifa > ab_glyph > dumb`, and the `config` / `font_preference` modules are now also gated on `cosmic-text`.
- **Sizing fix:** the original passed `1.4 * pt_size * 96/72` (the *line height*) as the em size to `layout()`, so every glyph was ~40% too large. Now the point size is the em size, and the pixmap is sized from the run's `max_ascent + max_descent` with the baseline at `max_ascent` — previously the baseline was pinned to the pixmap's bottom edge, clipping descenders.
- **Style:** the GNOME `titlebar-font` style descriptor ("Bold", "Italic", …) is mapped onto cosmic-text weight/style attrs (was a `// TODO`).
- Composites with alpha blending and guards the x range so a glyph can't wrap onto the next row.

## Notes / open questions

- Pinned to `cosmic-text = "0.10"` (as in the original PR). Happy to bump to a current release if you'd prefer — that's a small follow-up but pulls in API changes.
- This supersedes my #97 (the `ab_glyph` + per-codepoint `fc-match` fallback). cosmic-text is the smaller, more capable change — one renderer with real shaping instead of bolting fallback onto each backend — so I'll close #97 in favour of this.

Closes #16 (supersedes), refs #96, supersedes #97.
