### PR TITLE
Add a range for skrifa version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Support a range of skrifa versions.
 - Add the option to hide the borders `FrameConfig::hide_border`
 - Simplify `skrifa` title creation.
 - `skrifa` feature got added (for `skrifa` based title rendering)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ crossfont = { version = "0.9.0", optional = true }
 # Draw title text using ab_glyph `--features ab_glyph`
 ab_glyph = { version = "0.2.17", optional = true }
 # Draw title text using skrifa + tiny-skia `--features skrifa`
-skrifa = { version = "0.40", optional = true }
+skrifa = { version = ">=0.40, <=0.44", optional = true }
 # Draw title text using cosmic-text `--features cosmic-text`
 cosmic-text = { version = "0.19.0", optional = true }
 


### PR DESCRIPTION
This seems like a feasible solution to deal with inconsistent versions in different dependencies.

~(I have not tried the intermediate versions, but only 0.40 which was the previous and 0.44 which is the latest.)~

Edit: `cargo test --all-features` for all upper bounds between 0.40 and 0.44.

Edit 2: Sort of stating the obvious, but it would be nice to get this in for 0.11.1 as it will allow bumping a series of crates (ending up with egui for my use case). Although not fully true. The tiny-skia bump is more relevant since skrifa is optional here, but still.