### PR TITLE
Simplify skrifa rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 - Add the option to hide the borders `FrameConfig::hide_border`
+- Simplify `skrifa` title creation.
 - `skrifa` feature got added (for `skrifa` based title rendering)
     - Can be enabled like this:
         ```toml
@@ -14,7 +15,7 @@
 ## 0.11.0
 - Improve `ab_glyph` rendering to properly account for glyph outlines that would have previously been out of bounds
 - Align with new adwaita blue tint #71
-- Add ability to hide the titlebar #69 
+- Add ability to hide the titlebar #69
 - Bump sctk to 0.20
 - Bump crossfont to 0.9.0
 
@@ -46,8 +47,8 @@
 - **Breaking:** `wayland-csd-frame` is now used as a part of the public interface.
 
 ## 0.6.1
-- Bump tiny-skia to v0.11 (#32) 
-- cleanup: Remove debug println (#29) 
+- Bump tiny-skia to v0.11 (#32)
+- cleanup: Remove debug println (#29)
 - Support custom header buttons layouts (#30)
 - The double click threshold value was raised to `400ms`
 
@@ -79,7 +80,7 @@
 - `title` feature got removed
 - `ab_glyph` default feature got added (for `ab_glyph` based title rendering)
 - `crossfont` feature got added (for `crossfont` based title rendering)
-    - Can be enable like this: 
+    - Can be enable like this:
         ```toml
         sctk-adwaita = { default-features = false, features = ["crossfont"] }
         ```

--- a/src/title/skrifa_renderer.rs
+++ b/src/title/skrifa_renderer.rs
@@ -33,7 +33,9 @@ impl SkrifaTitleText {
             .and_then(|f| mmap(&f))
             .map(|mmap| (mmap, font_pref));
 
-        let px_size = pt_to_px(&font, font_pref_pt_size);
+        // Convert point size to pixel size.
+        // 1pt = 1/72in, 1px = 1/96in, so px = pt * (96/72)
+        let px_size = font_pref_pt_size * (96.0 / 72.0);
 
         Self {
             title: <_>::default(),
@@ -163,20 +165,6 @@ impl SkrifaTitleText {
         }
 
         Some(pixmap)
-    }
-}
-
-/// Convert point size to pixel size using font's units_per_em.
-fn pt_to_px(font_data: &Option<(memmap2::Mmap, FontPreference)>, pt_size: f32) -> f32 {
-    let font = parse_font(font_data);
-    let metrics = font.metrics(Size::unscaled(), LocationRef::default());
-    let units_per_em = metrics.units_per_em as f32;
-    if units_per_em > 0.0 {
-        // Standard conversion: 1pt = 1.333px at 96dpi (96/72)
-        pt_size * (96.0 / 72.0)
-    } else {
-        // Fallback
-        pt_size * 1.333
     }
 }
 


### PR DESCRIPTION
Closes #102 

I talked a bit with Claude Code about this and it confirmed that skrifa does the corresponding conversion, so no need to read the fontfile and barely use the information.